### PR TITLE
Feature - Allow for search via URL query

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,11 +69,10 @@ export default {
     },
     created() {
         this.data = data;
-        const { query } = this.$route;
-        this.filter = query.search || '';
     },
     mounted() {
-      this.$refs.search.value = this.filter;
+      const { query } = this.$route;
+      this.$refs.search.value = this.filter = query.search || '';
         Mousetrap.bind(['command+k', 'ctrl+k'], (event) => {
             this.$refs.search.focus();
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -133,8 +133,8 @@ export default {
     this.data = data
   },
   mounted() {
-    const { query } = this.$route;
-    this.$refs.search.value = this.filter = query.search || '';
+    const { query } = this.$route
+    this.$refs.search.value = this.filter = query.search || ''
     Mousetrap.bind(['command+k', 'ctrl+k'], event => {
       this.$refs.search.focus()
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,8 +69,11 @@ export default {
     },
     created() {
         this.data = data;
+        const { query } = this.$route;
+        this.filter = query.search || '';
     },
     mounted() {
+      this.$refs.search.value = this.filter;
         Mousetrap.bind(['command+k', 'ctrl+k'], (event) => {
             this.$refs.search.focus();
 


### PR DESCRIPTION
In order to quickly use documentation provided by artisan.page via external sources like [Alfred](https://www.alfredapp.com/), it would be great if a search could be made through the query params.
This commit will allow a user to find documentation by adding `?search={query}` to the URL and actually making a search.
The value of the search field will then be populated by the query param.

Thank you for your consideration.