### PR TITLE
Command List

### DIFF
--- a/components/ArtisanBrowser.vue
+++ b/components/ArtisanBrowser.vue
@@ -133,9 +133,7 @@
 
       <div class="flex my-8">
         <div class="hidden md:block md:w-1/4">
-          <h3 class="text-xl font-bold text-indigo-900">
-            Available commands:
-          </h3>
+          <h3 class="text-xl font-bold text-indigo-900">Available commands:</h3>
 
           <div v-for="(group, groupName) in commandLinks">
             <h3 class="text-lg font-bold text-indigo-900">
@@ -177,7 +175,9 @@
                   text-center
                 "
               >
-                <h1 class="text-xl font-bold text-indigo-900">No Commands Found</h1>
+                <h1 class="text-xl font-bold text-indigo-900">
+                  No Commands Found
+                </h1>
                 <p>
                   Nothing found for <code class="font-mono">{{ filter }}</code>
                 </p>
@@ -264,7 +264,7 @@ export default {
     },
     commandLinks() {
       return this.getCommandLinks()
-    }
+    },
   },
   methods: {
     getCommands(keyword) {
@@ -301,8 +301,8 @@ export default {
       // display the 'ungrouped' commands at the top of the list.
       return Object.fromEntries(
         Object.entries(commandLinks).sort((a, b) => a[0] > b[0])
-      );
-    }
+      )
+    },
   },
 }
 </script>

--- a/components/ArtisanBrowser.vue
+++ b/components/ArtisanBrowser.vue
@@ -131,44 +131,56 @@
         </form>
       </div>
 
-      <div class="space-y-8 my-8">
-        <div v-if="!data.length">
-          <div
-            class="
-              rounded-xl
-              shadow-lg
-              overflow-hidden
-              bg-white
-              p-10
-              text-center
-            "
-          >
-            <p class="text-xl font-bold text-indigo-900">Loading...</p>
-          </div>
-        </div>
-        <div v-else-if="commands.length == 0">
-          <div
-            class="
-              rounded-xl
-              shadow-lg
-              overflow-hidden
-              bg-white
-              p-10
-              text-center
-            "
-          >
-            <h1 class="text-xl font-bold text-indigo-900">No Commands Found</h1>
-            <p>
-              Nothing found for <code class="font-mono">{{ filter }}</code>
-            </p>
-          </div>
+      <div class="flex my-8">
+        <div class="hidden md:block md:w-1/4 space-y-2">
+          <command-link
+            v-for="command in data"
+            :key="command.name"
+            :command="command"
+          />
         </div>
 
-        <command
-          v-for="command in commands"
-          :key="command.name"
-          :command="command"
-        />
+        <div class="w-full md:w-3/4">
+          <div class="space-y-8">
+            <div v-if="!data.length">
+              <div
+                class="
+                  rounded-xl
+                  shadow-lg
+                  overflow-hidden
+                  bg-white
+                  p-10
+                  text-center
+                "
+              >
+                <p class="text-xl font-bold text-indigo-900">Loading...</p>
+              </div>
+            </div>
+            <div v-else-if="commands.length == 0">
+              <div
+                class="
+                  rounded-xl
+                  shadow-lg
+                  overflow-hidden
+                  bg-white
+                  p-10
+                  text-center
+                "
+              >
+                <h1 class="text-xl font-bold text-indigo-900">No Commands Found</h1>
+                <p>
+                  Nothing found for <code class="font-mono">{{ filter }}</code>
+                </p>
+              </div>
+            </div>
+
+            <command
+              v-for="command in commands"
+              :key="command.name"
+              :command="command"
+            />
+          </div>
+        </div>
       </div>
     </main>
   </div>

--- a/components/ArtisanBrowser.vue
+++ b/components/ArtisanBrowser.vue
@@ -132,12 +132,22 @@
       </div>
 
       <div class="flex my-8">
-        <div class="hidden md:block md:w-1/4 space-y-2">
-          <command-link
-            v-for="command in data"
-            :key="command.name"
-            :command="command"
-          />
+        <div class="hidden md:block md:w-1/4">
+          <h3 class="text-xl font-bold text-indigo-900">
+            Available commands:
+          </h3>
+
+          <div v-for="(group, groupName) in commandLinks">
+            <h3 class="text-lg font-bold text-indigo-900">
+              {{ groupName }}
+            </h3>
+
+            <command-link
+              v-for="command in group"
+              :key="command.name"
+              :command="command"
+            />
+          </div>
         </div>
 
         <div class="w-full md:w-3/4">
@@ -252,6 +262,9 @@ export default {
 
       return this.getCommands(keyword)
     },
+    commandLinks() {
+      return this.getCommandLinks()
+    }
   },
   methods: {
     getCommands(keyword) {
@@ -269,6 +282,27 @@ export default {
       const data = await import(`../assets/${version}.json`)
       this.data = data.default
     },
+    getCommandLinks() {
+      let commandLinks = {}
+
+      this.data.forEach(command => {
+        const groupName = command.name.includes(':')
+          ? command.name.split(':')[0]
+          : ''
+
+        if (commandLinks[groupName] === undefined) {
+          commandLinks[groupName] = []
+        }
+
+        commandLinks[groupName].push(command)
+      })
+
+      // Sort the commands into alphabetical order so that we can
+      // display the 'ungrouped' commands at the top of the list.
+      return Object.fromEntries(
+        Object.entries(commandLinks).sort((a, b) => a[0] > b[0])
+      );
+    }
   },
 }
 </script>

--- a/components/ArtisanBrowser.vue
+++ b/components/ArtisanBrowser.vue
@@ -133,10 +133,10 @@
 
       <div class="flex my-8">
         <div class="hidden md:block md:w-1/4">
-          <h3 class="text-xl font-bold text-indigo-900">Available commands:</h3>
+          <h2 class="text-xl font-bold text-indigo-900">Available Commands</h2>
 
-          <div v-for="(group, groupName) in commandLinks">
-            <h3 class="text-lg font-bold text-indigo-900">
+          <div v-for="(group, groupName) in commandLinks" class="mb-2">
+            <h3 class="text-lg font-semibold text-indigo-900">
               {{ groupName }}
             </h3>
 
@@ -144,6 +144,7 @@
               v-for="command in group"
               :key="command.name"
               :command="command"
+              class="text-sm"
             />
           </div>
         </div>

--- a/components/CommandLink.vue
+++ b/components/CommandLink.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <a
-      class="text-gray-700 hover:text-indigo-900 hover:underline"
+      class="ml-5 text-gray-700 hover:text-indigo-900 hover:underline inline-block mb-1"
       :href="`#${slug}`"
     >
       {{ command.name }}

--- a/components/CommandLink.vue
+++ b/components/CommandLink.vue
@@ -4,8 +4,7 @@
       class="
         ml-5
         text-gray-700
-        hover:text-indigo-900
-        hover:underline
+        hover:text-indigo-900 hover:underline
         inline-block
         mb-1
       "

--- a/components/CommandLink.vue
+++ b/components/CommandLink.vue
@@ -1,18 +1,18 @@
 <template>
-  <div>
-    <a
-      class="
-        ml-5
-        text-gray-700
-        hover:text-indigo-900 hover:underline
-        inline-block
-        mb-1
-      "
-      :href="`#${slug}`"
-    >
-      {{ command.name }}
-    </a>
-  </div>
+  <a
+    class="
+      ml-5
+      text-gray-600
+      hover:text-gray-900 hover:underline
+      block
+      mb-1
+    "
+    :href="`#${slug}`"
+    :title="command.description"
+    v-bind="$attrs"
+  >
+    {{ command.name }}
+  </a>
 </template>
 
 <script>

--- a/components/CommandLink.vue
+++ b/components/CommandLink.vue
@@ -1,7 +1,14 @@
 <template>
   <div>
     <a
-      class="ml-5 text-gray-700 hover:text-indigo-900 hover:underline inline-block mb-1"
+      class="
+        ml-5
+        text-gray-700
+        hover:text-indigo-900
+        hover:underline
+        inline-block
+        mb-1
+      "
       :href="`#${slug}`"
     >
       {{ command.name }}

--- a/components/CommandLink.vue
+++ b/components/CommandLink.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <a
+      class="text-gray-700 hover:text-indigo-900 hover:underline"
+      :href="`#${slug}`"
+    >
+      {{ command.name }}
+    </a>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['command'],
+  computed: {
+    slug() {
+      return this.command.name.replace(':', '')
+    },
+  },
+}
+</script>


### PR DESCRIPTION
Hey James!

This PR adds a list of the commands to the left-hand side of the page in the desktop view. I thought it'd be a pretty nice way of being able to quickly view the available commands.

I've taken the same sort of approach with how `php artisan` would work if you ran it in your console (like in the screenshot). So, the 'ungrouped' commands that don't have a prefix before `:` will be placed at the top of the list. Any after that will then be grouped by their prefix.

Each of the commands on the left-hand side take you straight you to the command info when clicked on, so it acts as a form of navigation.

I've not added anything for the mobile view because I thought it might just get in the way more than anything. If you think a mobile list would be useful though, I'd be happy to get one added.

By the way, I'm by no means a JS developer, so if there's anything that I've done that looks a bit odd, I apologise in advance haha!

Hopefully it's something that you'll consider pulling in, but if you do need any changes making for it, please let me know 😄 

<img width="1431" alt="Screenshot 2021-11-15 at 22 44 35" src="https://user-images.githubusercontent.com/39652331/141865237-6ec5ffca-8c49-4faa-b0d0-6589e89e2fab.png">
<img width="698" alt="Screenshot 2021-11-15 at 22 46 47" src="https://user-images.githubusercontent.com/39652331/141865245-f89ab4bc-73a0-428f-8cad-9aa4fbeb10d3.png">
