### PR TITLE
Add auto discovery ci script

### DIFF
--- a/.github/workflows/process-artisan-commands.yml
+++ b/.github/workflows/process-artisan-commands.yml
@@ -1,6 +1,7 @@
 name: Process Artisan Commands
 on:
   workflow_dispatch:
+  push:
   schedule:
     - cron: '0 0 * * 3'
 

--- a/.github/workflows/process-artisan-commands.yml
+++ b/.github/workflows/process-artisan-commands.yml
@@ -1,7 +1,6 @@
 name: Process Artisan Commands
 on:
   workflow_dispatch:
-  push:
   schedule:
     - cron: '0 0 * * 3'
 

--- a/.github/workflows/process-artisan-commands.yml
+++ b/.github/workflows/process-artisan-commands.yml
@@ -50,14 +50,17 @@ jobs:
       - name: Setup PHP, with Composer and extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.laravel.php }}
           extensions: dom, curl, libxml, mbstring, zip
           tools: composer:v2
+
+      - name: Install Laravel
+        run: composer create-project --no-progress laravel/laravel="^${{ matrix.laravel.v }}" /tmp/laravel
 
       - name: Run Generator Command
         run: |
           cd /tmp/laravel
-          cat ${{ github.workspace }}/scripts/generate | php artisan tinker > /tmp/${{ matrix.laravel.v }}.x.json | true
+          cat ${{ github.workspace }}/build | php artisan tinker > /tmp/${{ matrix.laravel.v }}.x.json | true
 
       - name: Commit comand files if needed #it fails if nothing has changed so we allow an error
         run: |

--- a/.github/workflows/process-artisan-commands.yml
+++ b/.github/workflows/process-artisan-commands.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Set up git user
         run: |
-          git config --global user.name GitHub Actions
-          git config --global user.email github-actions[bot]@users.noreply.github.com
+          git config --global user.name ${GITHUB_ACTOR}
+          git config --global user.email ${GITHUB_ACTOR}@users.noreply.github.com
 
       - name: Setup PHP, with Composer and extensions
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/process-artisan-commands.yml
+++ b/.github/workflows/process-artisan-commands.yml
@@ -1,57 +1,51 @@
 name: Process Artisan Commands
-
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 3'
 
 jobs:
-  prepare:
-    name: Prepare manifest file
-
+  fetch_laravel_versions:
+    name: Fetch Latest Laravel Versions
     runs-on: ubuntu-latest
-    
+    outputs:
+      matrix: ${{ steps.fetch_versions.outputs.matrix }}
+    steps:
+      - name: Get versions from Packagist
+        id: fetch_versions
+        run: |
+          # Fetch the latest Laravel versions from Packagist
+          # Convert to JSON e.g {v: "8", php: ">=7.3.0"}
+          # Extract the versions and their PHP requirements
+          # Remove duplicate lines based on the first column
+          # Remove v5.x versions as the putput breaks
+          # Get major v only, dedupe, and combine on one line
+          # Output the JSON to the step output
+          curl -s https://packagist.org/packages/laravel/laravel.json \
+          | jq -r '.package.versions[] | select(.require.php != null) | select(.version_normalized != null) | .version_normalized, .require.php' \
+          | sed -e '/dev/,+1d' -e '1~2 s/\..*//' -e '2~2 s/|.*$//' -e 's/[^0-9]*//' \
+          | cut -f1,2 -d'.' \
+          | awk 'NR%2{printf "%s ",$0;next;}1' \
+          | sort -Vru -k1,1 \
+          | sed '/^5 /d' \
+          | jq -Rcn '[inputs | split(" ") | {v:.[0], php:.[1]}]' \
+          | tee /tmp/versions.json
+          echo "matrix=$(cat /tmp/versions.json)" >> "$GITHUB_OUTPUT"
+  generate:
+    needs: fetch_laravel_versions
+    name: Laravel v${{ matrix.laravel.v }} - PHP ${{ matrix.laravel.php }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        laravel: [6, 7, 8, 9, 10]
-
+        laravel: ${{ fromJson(needs.fetch_laravel_versions.outputs.matrix) }}
     steps:
-    - name: Check out source code
-      uses: actions/checkout@v3
-
-#    - name: Import packages
-#      id: set-packages
-#      run: |
-#        packages=`cat ${{ github.workspace }}/manifest.json | jq --compact-output '. | {packages: (.packages | join(" "))}'`
-#        echo $packages
-#        echo "::set-output name=packages::$packages"
-
-  commands:
-    needs: prepare
-
-    name: Laravel Version ${{ matrix.laravel }}
-
-    runs-on: ubuntu-latest
-    
-    strategy:
-      fail-fast: false
-      matrix: 
-        php: [7.4]
-        laravel: [6, 7, 8]
-        include:
-          - php: '8.0'
-            laravel: 9
-          - php: '8.1'
-            laravel: 10
-
-    steps:
-      - name: Check out source code
+      - name: Check out code
         uses: actions/checkout@v3
+
+      - name: Set up git user
+        run: |
+          git config --global user.name GitHub Actions
+          git config --global user.email github-actions[bot]@users.noreply.github.com
 
       - name: Setup PHP, with Composer and extensions
         uses: shivammathur/setup-php@v2
@@ -60,24 +54,10 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip
           tools: composer:v2
 
-      - name: Install Laravel
-        run: composer create-project --no-progress laravel/laravel="^${{ matrix.laravel }}" /tmp/laravel
-
-#      - name: Install Laravel packages
-#        run: |
-#          cd /tmp/laravel
-#          composer require --no-progress --no-interaction --ignore-platform-reqs ${{fromJson(needs.prepare.outputs.packages).packages}}
-#        continue-on-error: true
-
-      - name: Build Generator Command
+      - name: Run Generator Command
         run: |
           cd /tmp/laravel
-          cat ${{ github.workspace }}/build | php artisan tinker > /tmp/${{ matrix.laravel }}.x.json | true
-      - name: Configure Git Name
-        run: git config --global user.name ${GITHUB_ACTOR}
-
-      - name: Configure Git Email
-        run: git config --global user.email ${GITHUB_ACTOR}@users.noreply.github.com
+          cat ${{ github.workspace }}/scripts/generate | php artisan tinker > /tmp/${{ matrix.laravel.v }}.x.json | true
 
       - name: Commit comand files if needed #it fails if nothing has changed so we allow an error
         run: |
@@ -88,11 +68,13 @@ jobs:
             git reset --hard HEAD
             git clean -f -d
             git pull || true
-            cp /tmp/${{ matrix.laravel }}.x.json ./assets/
+            cp /tmp/${{ matrix.laravel.v }}.x.json ./assets/
             git add -A || true
-            git commit -am 'Build Laravel version v${{ matrix.laravel }}' || true
+            git commit -am 'Build Laravel version v${{ matrix.laravel.v }}' || true
             git push --force && break
             n=$((n+1))
             sleep 15
           done
+        env:
+          matrix: ${{ needs.fetch_laravel_versions.outputs.matrix }}
         continue-on-error: true


### PR DESCRIPTION
This keeps the data sources up to date automatically when new Laravel versions are released. It also will auto use the correct PHP version, so you there's no need to maintain the strategy matrix.

Example run: https://github.com/KevinBatdorf/artisan.page/actions/runs/4898999384

New stuff:

- Fetch all the major Laravel versions from packagist.org along with their required PHP versions.
- Iterate over each item, creating a new workflow for each version
- Install the Laravel version + php version

I removed the push and pull_request triggers and added a manual trigger, but feel free to add those back, and just feel free of course to take over the PR and change anything!

It would be good to keep an eye on this when Laravel 11 is released though, of course.

closes [#9 ](https://github.com/jbrooksuk/artisan.page/issues/31)