### PR TITLE
Add latest alias for latest Laravel version

### DIFF
--- a/server/api/[version].js
+++ b/server/api/[version].js
@@ -12,7 +12,11 @@ const versionMap = {
 }
 
 export default defineEventHandler(async (event) => {
-  const version = getRouterParam(event, 'version')
+  let version = getRouterParam(event, 'version')
+
+  if (version === 'latest') {
+    version = laravel[0]
+  }
 
   if (!laravel.includes(version)) {
     throw createError({


### PR DESCRIPTION
API will now accept `/api/latest` and treat it as if it were `/api/12.x`, or whatever the latest version is according to the `manifest.laravel` entry.