### PR TITLE
Add Fathom event tracking for sidebar interactions

### DIFF
--- a/components/ArtisanBrowser.vue
+++ b/components/ArtisanBrowser.vue
@@ -254,6 +254,10 @@ export default {
     },
     filterResults(value) {
       this.filter = value.trim()
+
+      if (this.filter && typeof window.fathom !== 'undefined') {
+        window.fathom.trackEvent('Command Search')
+      }
     },
     setupScrollObserver() {
       if (this._observer) {
@@ -273,7 +277,14 @@ export default {
             .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
 
           if (visible.length > 0) {
-            this.activeCommand = visible[0].target.dataset.command
+            const newCommand = visible[0].target.dataset.command
+            if (newCommand !== this.activeCommand) {
+              this.activeCommand = newCommand
+
+              if (typeof window.fathom !== 'undefined') {
+                window.fathom.trackEvent('Command Scroll')
+              }
+            }
           }
         },
         {

--- a/components/CommandLink.vue
+++ b/components/CommandLink.vue
@@ -8,6 +8,7 @@
       : 'text-gray-700 dark:text-gray-400 hover:text-artisan-accent dark:hover:text-artisan-accent'"
     :title="command.description"
     v-bind="$attrs"
+    @click="trackEvent"
   >
     {{ command.name }}
   </NuxtLink>
@@ -50,6 +51,12 @@ export default {
     handleCommandClick() {
       scrollToAnchor(this.slug)
       this.refreshCarbon()
+      this.trackEvent()
+    },
+    trackEvent() {
+      if (typeof window.fathom !== 'undefined') {
+        window.fathom.trackEvent('Sidebar Command Click')
+      }
     },
     refreshCarbon() {
       if (typeof _carbonads !== 'undefined') _carbonads.refresh()


### PR DESCRIPTION
## Summary
- Track **Sidebar Command Click** events when users click command links in the sidebar
- Track **Command Search** events when users type a search query
- Track **Command Scroll** events when scrolling changes the active command in view

All three use `fathom.trackEvent()` with the existing `window.fathom` guard pattern.

## Test plan
- [ ] Verify events appear in Fathom dashboard after clicking sidebar commands
- [ ] Verify search event fires when typing in the search box
- [ ] Verify scroll event fires when scrolling through commands in the main content area
- [ ] Confirm no errors in production (Fathom script only loads in prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)