### PR TITLE
Prerender all routes for static caching

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,10 +1,20 @@
 import { laravel } from './manifest'
 
 export default defineNuxtConfig({
-  // Target: https://go.nuxtjs.dev/config-target
-  target: 'static',
-
   ssr: true,
+
+  routeRules: {
+    '/': { prerender: true },
+    '/**': { prerender: true },
+    '/api/**': { prerender: false },
+  },
+
+  nitro: {
+    prerender: {
+      crawlLinks: true,
+      routes: ['/'],
+    },
+  },
 
   site: {
     url: 'https://artisan.page',


### PR DESCRIPTION
## Summary
- Replace the inert Nuxt 2 `target: 'static'` flag with Nitro `routeRules` that mark every page route as `prerender: true`, so `nuxi build` emits flat HTML into `.output/public/` and `node .output/server/index.mjs` serves it without per-request rendering.
- Enable `nitro.prerender.crawlLinks` from `/` so all `/[version]/...` pages are discovered and rendered at build time.
- Keep `/api/**` dynamic so the og-image, sitemap, packages, and version endpoints continue to render on demand.

## Test plan
- [x] `npm run build` completes and `.output/public/` contains `index.html` plus an HTML file for each Laravel version page
- [x] `node .output/server/index.mjs` serves `/` and a sample `/<version>/...` route from the prerendered HTML (no SSR work in the response)
- [x] `/api/og`, `/api/packages`, `/api/versions`, and `/sitemap.xml` still respond dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)