### PR TITLE
Make OG image generation static per version + command

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,17 @@
+import { readFileSync } from 'node:fs'
 import { laravel } from './manifest'
+
+const prerenderRoutes = laravel.flatMap((version) => {
+  const commands = JSON.parse(readFileSync(`./assets/${version}.json`, 'utf-8'))
+  return [
+    `/${version}`,
+    `/og/${version}.png`,
+    ...commands.flatMap(c => [
+      `/${version}/${c.name.replace(':', '')}`,
+      `/og/${version}/${c.name.replace(':', '')}.png`,
+    ]),
+  ]
+})
 
 export default defineNuxtConfig({
   ssr: true,
@@ -12,7 +25,7 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       crawlLinks: true,
-      routes: ['/'],
+      routes: ['/', ...prerenderRoutes],
     },
   },
 
@@ -116,7 +129,7 @@ export default defineNuxtConfig({
     groups: [
       {
         userAgent: '*',
-        allow: ['/', '/api/og'],
+        allow: ['/', '/og/'],
         disallow: ['/api/'],
       },
     ],

--- a/pages/[version]/[command].vue
+++ b/pages/[version]/[command].vue
@@ -50,7 +50,7 @@ const cleanDescription = sanitise(command.description, 200)
 const metaDescription = sanitise(`php artisan ${command.name} — ${cleanDescription} — Laravel ${commandVersion}`, 155)
 const socialDescription = sanitise(`${cleanDescription} — Laravel ${commandVersion} Artisan command reference.`, 200)
 
-const ogImageUrl = `https://artisan.page/api/og?command=${encodeURIComponent(command.name)}&description=${encodeURIComponent(cleanDescription)}&version=${encodeURIComponent(commandVersion)}`
+const ogImageUrl = `https://artisan.page/og/${commandVersion}/${commandName}.png`
 
 useHead({
   link: [

--- a/pages/[version]/index.vue
+++ b/pages/[version]/index.vue
@@ -59,7 +59,7 @@ useHead({
   ],
 })
 
-const ogImageUrl = `https://artisan.page/api/og?version=${encodeURIComponent(version)}&count=${allCommands.length}`
+const ogImageUrl = `https://artisan.page/og/${version}.png`
 
 useSeoMeta({
   title: version,

--- a/server/routes/og/[version].png.js
+++ b/server/routes/og/[version].png.js
@@ -1,0 +1,21 @@
+import { loadCommandsFor, renderOgPng, renderVersionSvg } from '../../utils/og'
+
+export default defineEventHandler(async (event) => {
+  const params = event.context.params || {}
+  const version = (params.version ?? params['version.png'] ?? '').replace(/\.png$/, '')
+  const commands = await loadCommandsFor(version)
+
+  if (!commands) {
+    throw createError({ statusCode: 404, statusMessage: `Unknown version: ${version}` })
+  }
+
+  const svg = renderVersionSvg({ version, count: commands.length })
+  const pngBuffer = await renderOgPng(svg)
+
+  setResponseHeaders(event, {
+    'Content-Type': 'image/png',
+    'Cache-Control': 'public, max-age=86400, s-maxage=86400, immutable',
+  })
+
+  return pngBuffer
+})

--- a/server/routes/og/[version]/[command].png.js
+++ b/server/routes/og/[version]/[command].png.js
@@ -1,0 +1,40 @@
+import { loadCommandsFor, renderCommandSvg, renderOgPng } from '../../../utils/og'
+
+const sanitise = (text, max) => {
+  const cleaned = String(text).replace(/\s+/g, ' ').trim()
+  if (cleaned.length <= max) return cleaned
+  const truncated = cleaned.slice(0, max - 1)
+  const lastSpace = truncated.lastIndexOf(' ')
+  return (lastSpace > max * 0.6 ? truncated.slice(0, lastSpace) : truncated) + '…'
+}
+
+export default defineEventHandler(async (event) => {
+  const params = event.context.params || {}
+  const version = params.version
+  const commandSlug = (params.command ?? params['command.png'] ?? '').replace(/\.png$/, '')
+  const commands = await loadCommandsFor(version)
+
+  if (!commands) {
+    throw createError({ statusCode: 404, statusMessage: `Unknown version: ${version}` })
+  }
+
+  const command = commands.find(c => c.name.replace(':', '') === commandSlug)
+
+  if (!command) {
+    throw createError({ statusCode: 404, statusMessage: `Unknown command: ${commandSlug}` })
+  }
+
+  const svg = renderCommandSvg({
+    command: command.name,
+    description: sanitise(command.description, 200),
+    version,
+  })
+  const pngBuffer = await renderOgPng(svg)
+
+  setResponseHeaders(event, {
+    'Content-Type': 'image/png',
+    'Cache-Control': 'public, max-age=86400, s-maxage=86400, immutable',
+  })
+
+  return pngBuffer
+})

--- a/server/utils/og.js
+++ b/server/utils/og.js
@@ -31,24 +31,30 @@ function loadFontFiles() {
   return fontFilesPromise
 }
 
-export default defineEventHandler(async (event) => {
-  const query = getQuery(event)
-  const command = query.command ? String(query.command) : ''
-  const description = query.description ? String(query.description) : ''
-  const version = query.version ? String(query.version) : ''
-  const count = query.count ? String(query.count) : ''
+export const versionMap = {
+  '13.x': () => import('~/assets/13.x.json'),
+  '12.x': () => import('~/assets/12.x.json'),
+  '11.x': () => import('~/assets/11.x.json'),
+  '10.x': () => import('~/assets/10.x.json'),
+  '9.x': () => import('~/assets/9.x.json'),
+  '8.x': () => import('~/assets/8.x.json'),
+  '7.x': () => import('~/assets/7.x.json'),
+  '6.x': () => import('~/assets/6.x.json'),
+  '5.x': () => import('~/assets/5.x.json'),
+}
 
-  const svg = command
-    ? renderCommand({ command, description, version })
-    : renderVersion({ version, count })
+export async function loadCommandsFor(version) {
+  const loader = versionMap[version]
+  if (!loader) return null
+  const { default: commands } = await loader()
+  return commands
+}
 
+export async function renderOgPng(svg) {
   const fontFiles = await loadFontFiles()
 
   const resvg = new Resvg(svg, {
-    fitTo: {
-      mode: 'width',
-      value: 1200,
-    },
+    fitTo: { mode: 'width', value: 1200 },
     font: {
       fontFiles,
       loadSystemFonts: false,
@@ -56,18 +62,10 @@ export default defineEventHandler(async (event) => {
     },
   })
 
-  const pngData = resvg.render()
-  const pngBuffer = pngData.asPng()
+  return resvg.render().asPng()
+}
 
-  setResponseHeaders(event, {
-    'Content-Type': 'image/png',
-    'Cache-Control': 'public, max-age=86400, s-maxage=86400',
-  })
-
-  return pngBuffer
-})
-
-const SHARED_DEFS = `
+export const SHARED_DEFS = `
   <defs>
     <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" stop-color="#BB2926" />
@@ -114,7 +112,7 @@ const SHARED_DEFS = `
   <text x="1110" y="580" font-family="DM Sans" font-size="14" fill="#444444" text-anchor="end">artisan.page</text>
 `
 
-function renderCommand({ command, description, version }) {
+export function renderCommandSvg({ command, description, version }) {
   const versionText = version ? `Laravel ${version}` : ''
   const desc = description || 'The Laravel Artisan Cheatsheet'
 
@@ -135,7 +133,7 @@ function renderCommand({ command, description, version }) {
 </svg>`
 }
 
-function renderVersion({ version, count }) {
+export function renderVersionSvg({ version, count }) {
   const heading = version ? `Laravel ${version}` : 'Laravel'
   const subheading = count ? `${count} Artisan commands` : 'Artisan command reference'
 


### PR DESCRIPTION
## Summary
- Replaces the dynamic `/api/og?command=…&description=…&version=…&count=…` endpoint with two route-based handlers — `/og/{version}.png` and `/og/{version}/{command}.png` — so each OG image URL is fully determined by version + command and can be prerendered.
- Description and command count are now read server-side from `assets/{version}.json` instead of being passed in the URL, removing the long, brittle query-string OG URLs from the page meta.
- Adds the OG URLs **and** the corresponding `/[version]` / `/[version]/[command]` page URLs to `nitro.prerender.routes`. The home page renders no anchor tags for individual versions or commands (the browser is JS-driven), so `crawlLinks` alone wasn't discovering them — explicit enumeration from `manifest.laravel` + the per-version JSON gives full static coverage.
- Updates `pages/[version]/index.vue` and `pages/[version]/[command].vue` to point at the new path-based OG URLs, factors the SVG/font/Resvg logic into `server/utils/og.js`, and updates the robots allowlist (`/api/og` → `/og/`).

## Verification
After `nuxi build`, `.output/public/` contains:
- 1,729 HTML pages (home + 9 version landings + 1,719 command pages)
- 1,728 PNG OG images (9 version + 1,719 command)

`node .output/server/index.mjs` serves every checked route with `200 OK` + `Last-Modified`, no per-request rendering. Each PNG verifies as `1200x630, 8-bit/color RGBA`.

## Note on a Nitro routing quirk
For the nested `server/routes/og/[version]/[command].png.js`, Nitro exposes the inner bracket param under the literal key `command.png` (with the `.png` suffix retained in the value) instead of `command`. The same happens for the top-level `[version].png.js`. Both handlers read either key and strip the trailing `.png`, so they're resilient if Nitro changes this behaviour later.

## Test plan
- [ ] `npm run build` produces ~1.7k HTML files and ~1.7k PNG files in `.output/public/`
- [ ] `node .output/server/index.mjs` returns `200 OK` + `Content-Type: image/png` for `/og/13.x.png` and `/og/13.x/about.png` with no SSR latency
- [ ] `/13.x/about` HTML contains `og:image" content="https://artisan.page/og/13.x/about.png"`
- [ ] Sample share-link unfurls (Slack, Twitter, LinkedIn) on a deployed preview show the prerendered image

🤖 Generated with [Claude Code](https://claude.com/claude-code)