### PR TITLE
Add Deprecated badge for options marked (Deprecated)

### DIFF
--- a/components/Badge.vue
+++ b/components/Badge.vue
@@ -2,11 +2,13 @@
   <span
     class="badge-shine inline-flex items-center justify-center px-1 rounded text-[10px] font-medium leading-[17px] border-[0.5px] tracking-wide uppercase"
     :class="{
-      'bg-[rgba(211,64,62,0.03)] border-[rgba(211,64,62,0.6)] text-artisan-accent': required,
-      'bg-[#f4fcf6] border-[#73b78f] text-[#25613d]': !required,
+      'bg-[rgba(211,64,62,0.03)] border-[rgba(211,64,62,0.6)] text-artisan-accent': required && !deprecated,
+      'bg-[#f4fcf6] border-[#73b78f] text-[#25613d]': !required && !deprecated,
+      'bg-[#fdf6ec] border-[#d9a441] text-[#8a5a00]': deprecated,
     }"
   >
-    <template v-if="required">Required</template>
+    <template v-if="deprecated">Deprecated</template>
+    <template v-else-if="required">Required</template>
     <template v-else>Optional</template>
   </span>
 </template>
@@ -15,6 +17,7 @@
 export default {
   props: {
     required: Boolean,
+    deprecated: Boolean,
   },
 }
 </script>

--- a/components/Command.vue
+++ b/components/Command.vue
@@ -55,6 +55,7 @@
                 {{ formatOptionName(option.name) }}
               </span>
               <Badge :required="option.value_required" />
+              <Badge v-if="option.deprecated" deprecated />
             </div>
             <p class="text-[13px] text-gray-700 dark:text-gray-400 leading-5">
               <ConsoleText :text="option.description" />
@@ -127,8 +128,18 @@ export default {
   },
   computed: {
     commandOptions() {
-      return dataSortBy(this.command.options, {
+      const sorted = dataSortBy(this.command.options, {
         property: 'name',
+      })
+      return sorted.map((option) => {
+        const deprecated = /\(Deprecated\)/i.test(option.description)
+        return {
+          ...option,
+          deprecated,
+          description: deprecated
+            ? option.description.replace(/\s*\(Deprecated\)/i, '').trim()
+            : option.description,
+        }
       })
     },
     slug() {


### PR DESCRIPTION
## What

Options whose description ends with `(Deprecated)` now display a dedicated **Deprecated** badge instead of carrying the marker inline in the description text.

## Changes

- **`components/Command.vue`** — `commandOptions` detects a case-insensitive `(Deprecated)` marker, strips it from the option description, and exposes a `deprecated` flag. The template renders a separate `<Badge deprecated />` alongside the Required/Optional badge.
- **`components/Badge.vue`** — added a `deprecated` prop with an amber variant that renders the text "Deprecated".

## Why

The `(Deprecated)` suffix was buried in option descriptions across every `assets/*.x.json` version (e.g. `delay`, `daemon`, `fullpath`). Surfacing it as a distinct badge makes deprecated options easier to spot at a glance and keeps the description text clean. This is purely display logic, so it works across all versions without modifying the data files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)