### PR TITLE
Add Laravel Wayfinder package

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,7 @@
     "laravel/spark-stripe",
     "laravel/telescope",
     "laravel/vapor-core",
+    "laravel/wayfinder",
     "livewire/livewire",
     "livewire/volt",
     "inertiajs/inertia-laravel"
@@ -57,6 +58,7 @@
       "laravel/spark-stripe",
       "laravel/telescope",
       "laravel/vapor-core",
+      "laravel/wayfinder",
       "livewire/livewire",
       "livewire/volt",
       "inertiajs/inertia-laravel"
@@ -87,6 +89,7 @@
       "laravel/spark-stripe",
       "laravel/telescope",
       "laravel/vapor-core",
+      "laravel/wayfinder",
       "livewire/livewire",
       "livewire/volt",
       "inertiajs/inertia-laravel"
@@ -117,6 +120,7 @@
       "laravel/spark-stripe",
       "laravel/telescope",
       "laravel/vapor-core",
+      "laravel/wayfinder",
       "livewire/livewire",
       "livewire/volt",
       "inertiajs/inertia-laravel"


### PR DESCRIPTION
## Summary

- add `laravel/wayfinder` to the package catalog
- enable it for Laravel 11.x, 12.x, and 13.x, matching its current Illuminate constraints

## Testing

- `git diff --check`
- focused Node manifest compatibility validation
- full Vitest suite not run locally (`node_modules` is not installed)