### PR TITLE
Add Markdown routes and full LLM reference

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,12 +2,20 @@ import { readFileSync } from 'node:fs'
 import { laravel } from './manifest'
 
 const prerenderRoutes = laravel.flatMap((version) => {
-  const commands = JSON.parse(readFileSync(`./assets/${version}.json`, 'utf-8'))
+  let commands
+  try {
+    commands = JSON.parse(readFileSync(`./assets/${version}.json`, 'utf-8'))
+  } catch (err) {
+    console.warn(`[nuxt.config] Skipping Laravel ${version}: assets/${version}.json could not be parsed (${err.message})`)
+    return []
+  }
   return [
     `/${version}`,
+    `/${version}.md`,
     `/og/${version}.png`,
     ...commands.flatMap(c => [
       `/${version}/${c.name.replace(':', '')}`,
+      `/${version}/${c.name.replace(':', '')}.md`,
       `/og/${version}/${c.name.replace(':', '')}.png`,
     ]),
   ]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "generate:llms": "node scripts/generate-llms.mjs",
+    "predev": "npm run generate:llms",
+    "prebuild": "npm run generate:llms",
+    "pregenerate": "npm run generate:llms",
     "dev": "nuxi dev",
     "build": "nuxi build",
     "start": "nuxi start",

--- a/public/.well-known/agent-skills/artisan-commands/SKILL.md
+++ b/public/.well-known/agent-skills/artisan-commands/SKILL.md
@@ -13,15 +13,17 @@ Artisan.page is a complete reference for every `php artisan` command shipped wit
 - Home: `https://artisan.page`
 - Version listing: `https://artisan.page/{version}` (e.g. `https://artisan.page/13.x`)
 - Command detail: `https://artisan.page/{version}/{command}` (e.g. `https://artisan.page/13.x/makemigration`)
+- Markdown version index: `https://artisan.page/{version}.md` (e.g. `https://artisan.page/13.x.md`)
+- Markdown command detail: `https://artisan.page/{version}/{command}.md` (e.g. `https://artisan.page/13.x/makemigration.md`)
 
 Colons in command names are stripped from the URL path: `make:migration` becomes `makemigration`, `cache:clear` becomes `cacheclear`.
 
 ## Fetching content as an agent
 
-All HTML pages support content negotiation. Send `Accept: text/markdown` and the response body will be a clean markdown representation of the page, with `Content-Type: text/markdown; charset=utf-8` and an `x-markdown-tokens` header estimating the markdown token count. Without that header the default response is HTML.
+Use a `.md` URL for a Markdown response without content negotiation. Canonical HTML pages also support `Accept: text/markdown`; those responses include `Content-Type: text/markdown; charset=utf-8` and an `x-markdown-tokens` header estimating the Markdown token count. Without the extension or header, the default response is HTML.
 
 ```bash
-curl -H "Accept: text/markdown" https://artisan.page/13.x/makemigration
+curl https://artisan.page/13.x/makemigration.md
 ```
 
 ## JSON API

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,25495 @@
+# Artisan.page: Complete Artisan Command Reference
+
+> Every documented Laravel `php artisan` command, organised by framework version.
+
+For a compact index with links to each command page, see [llms.txt](https://artisan.page/llms.txt).
+
+## Laravel 13.x
+
+262 documented commands.
+
+### `php artisan _complete`
+
+Internal command to provide shell completion suggestions
+
+```bash
+php artisan _complete [-s|--shell SHELL] [-i|--input INPUT] [-c|--current CURRENT] [-a|--api-version API-VERSION] [-S|--symfony SYMFONY]
+```
+
+Options:
+- `--api-version` (value required) — The API version of the completion script
+- `--current` (value required) — The index of the "input" array that the cursor is in (e.g. COMP_CWORD)
+- `--input` (value required) — An array of input tokens (e.g. COMP_WORDS or argv)
+- `--shell` (value required) — The shell type ("bash", "fish", "zsh")
+- `--symfony` (value required) — deprecated
+
+Source: https://artisan.page/13.x/_complete.md
+
+### `php artisan about`
+
+Display basic information about your application
+
+```bash
+php artisan about [--only [ONLY]] [--json]
+```
+
+Options:
+- `--json` — Output the information as JSON
+- `--only` (value optional) — The section to display
+
+Source: https://artisan.page/13.x/about.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/13.x/authclear-resets.md
+
+### `php artisan boost:add-skill`
+
+Add skills from a remote GitHub repository
+
+```bash
+php artisan boost:add-skill [--list] [--all] [--skill [SKILL]] [--force] [--skip-audit] [--] [<repo>]
+```
+
+Arguments:
+- `repo` — GitHub repository (owner/repo or full URL)
+
+Options:
+- `--all` — Install all skills
+- `--force` — Overwrite existing skills
+- `--list` — List available skills
+- `--skill` (value optional) — Specific skills to install
+- `--skip-audit` — Skip security audit
+
+Source: https://artisan.page/13.x/boostadd-skill.md
+
+### `php artisan boost:execute-tool`
+
+Execute a Boost MCP tool in isolation (internal command)
+
+```bash
+php artisan boost:execute-tool <tool> <arguments>
+```
+
+Arguments:
+- `tool` (required)
+- `arguments` (required)
+
+Source: https://artisan.page/13.x/boostexecute-tool.md
+
+### `php artisan boost:install`
+
+```bash
+php artisan boost:install [--guidelines] [--skills] [--mcp]
+```
+
+Options:
+- `--guidelines` — Install AI guidelines
+- `--mcp` — Install MCP server configuration
+- `--skills` — Install agent skills
+
+Source: https://artisan.page/13.x/boostinstall.md
+
+### `php artisan boost:list-skills`
+
+List all available skills in the current project
+
+```bash
+php artisan boost:list-skills
+```
+
+Source: https://artisan.page/13.x/boostlist-skills.md
+
+### `php artisan boost:mcp`
+
+Starts Laravel Boost (usually from mcp.json)
+
+```bash
+php artisan boost:mcp
+```
+
+Source: https://artisan.page/13.x/boostmcp.md
+
+### `php artisan boost:update`
+
+Update the Laravel Boost guidelines & skills to the latest guidance
+
+```bash
+php artisan boost:update [--discover] [--ignore-skills]
+```
+
+Options:
+- `--discover` — Discover and prompt for newly available guidelines and skills
+- `--ignore-skills` — Skip updating the skills directory
+
+Source: https://artisan.page/13.x/boostupdate.md
+
+### `php artisan breeze:install`
+
+Install the Breeze controllers and resources
+
+```bash
+php artisan breeze:install [--dark] [--pest] [--ssr] [--typescript] [--eslint] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (blade,livewire,livewire-functional,react,vue,api)
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--eslint` — Indicates if ESLint with Prettier should be installed
+- `--pest` — Indicate that Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--typescript` — Indicates if TypeScript is preferred for the Inertia stack
+
+Source: https://artisan.page/13.x/breezeinstall.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--locks] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--locks` — Only clear cache locks
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/13.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/13.x/cacheforget.md
+
+### `php artisan cache:prune-stale-tags`
+
+Prune stale cache tags from the cache (Redis only)
+
+```bash
+php artisan cache:prune-stale-tags [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to prune tags from
+
+Source: https://artisan.page/13.x/cacheprune-stale-tags.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/13.x/cashierwebhook.md
+
+### `php artisan channel:list`
+
+List all registered private broadcast channels
+
+```bash
+php artisan channel:list
+```
+
+Source: https://artisan.page/13.x/channellist.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/13.x/clear-compiled.md
+
+### `php artisan completion`
+
+Dump the shell completion script
+
+```bash
+php artisan completion [--debug] [--] [<shell>]
+```
+
+Arguments:
+- `shell` — The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+Options:
+- `--debug` — Tail the completion debug log
+
+Source: https://artisan.page/13.x/completion.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/13.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/13.x/configclear.md
+
+### `php artisan config:publish`
+
+Publish configuration files to your application
+
+```bash
+php artisan config:publish [--all] [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the configuration file to publish
+
+Options:
+- `--all` — Publish all configuration files
+- `--force` — Overwrite any existing configuration files
+
+Source: https://artisan.page/13.x/configpublish.md
+
+### `php artisan config:show`
+
+Display all of the values for a given configuration file or key
+
+```bash
+php artisan config:show <config>
+```
+
+Arguments:
+- `config` (required) — The configuration file or key to show
+
+Source: https://artisan.page/13.x/configshow.md
+
+### `php artisan db`
+
+Start a new database CLI session
+
+```bash
+php artisan db [--read] [--write] [--pooled] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The database connection that should be used
+
+Options:
+- `--pooled` — Connect to the pooled connection
+- `--read` — Connect to the read connection
+- `--write` — Connect to the write connection
+
+Source: https://artisan.page/13.x/db.md
+
+### `php artisan db:monitor`
+
+Monitor the number of connections on the specified database
+
+```bash
+php artisan db:monitor [--databases [DATABASES]] [--max [MAX]]
+```
+
+Options:
+- `--databases` (value optional) — The database connections to monitor
+- `--max` (value optional) — The maximum number of connections that can be open before an event is dispatched
+
+Source: https://artisan.page/13.x/dbmonitor.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force] [--] [<class>]
+```
+
+Arguments:
+- `class` — The class name of the root seeder
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `Database\Seeders\DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/13.x/dbseed.md
+
+### `php artisan db:show`
+
+Display information about the given database
+
+```bash
+php artisan db:show [--database [DATABASE]] [--json] [--counts] [--views] [--types]
+```
+
+Options:
+- `--counts` — Show the table row count <bg=red;options=bold> Note: This can be slow on large databases </>
+- `--database` (value optional) — The database connection
+- `--json` — Output the database information as JSON
+- `--types` — Show the user defined types
+- `--views` — Show the database views <bg=red;options=bold> Note: This can be slow on large databases </>
+
+Source: https://artisan.page/13.x/dbshow.md
+
+### `php artisan db:table`
+
+Display information about the given database table
+
+```bash
+php artisan db:table [--database [DATABASE]] [--json] [--] [<table>]
+```
+
+Arguments:
+- `table` — The name of the table
+
+Options:
+- `--database` (value optional) — The database connection
+- `--json` — Output the table information as JSON
+
+Source: https://artisan.page/13.x/dbtable.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/13.x/dbwipe.md
+
+### `php artisan dev`
+
+Run the dev processes
+
+```bash
+php artisan dev
+```
+
+Source: https://artisan.page/13.x/dev.md
+
+### `php artisan dev:list`
+
+List the registered dev processes
+
+```bash
+php artisan dev:list [--json] [--filter FILTER] [--except-vendor] [--only-vendor]
+```
+
+Options:
+- `--except-vendor` — Do not display dev processes registered by vendor packages
+- `--filter` (value required) — Filter the dev processes by name or command
+- `--json` — Output the dev process list as JSON
+- `--only-vendor` — Only display dev processes registered by vendor packages
+
+Source: https://artisan.page/13.x/devlist.md
+
+### `php artisan docs`
+
+Access the Laravel documentation
+
+```bash
+php artisan docs [<page> [<section>]]
+```
+
+Arguments:
+- `page` — The documentation page to open
+- `section` — The section of the page to open
+
+Source: https://artisan.page/13.x/docs.md
+
+### `php artisan down`
+
+Put the application into maintenance / demo mode
+
+```bash
+php artisan down [--redirect [REDIRECT]] [--render [RENDER]] [--retry [RETRY]] [--refresh [REFRESH]] [--secret [SECRET]] [--with-secret] [--status [STATUS]]
+```
+
+Options:
+- `--redirect` (value optional) — The path that users should be redirected to
+- `--refresh` (value optional) — The number of seconds after which the browser may refresh
+- `--render` (value optional) — The view that should be prerendered for display during maintenance mode
+- `--retry` (value optional) — The number of seconds or the datetime after which the request may be retried
+- `--secret` (value optional) — The secret phrase that may be used to bypass maintenance mode
+- `--status` (value optional) — The status code that should be used when returning the maintenance mode response; default: `503`
+- `--with-secret` — Generate a random secret phrase that may be used to bypass maintenance mode
+
+Source: https://artisan.page/13.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/13.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/13.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/13.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/13.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/13.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/13.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/13.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/13.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/13.x/env.md
+
+### `php artisan env:decrypt`
+
+Decrypt an environment file
+
+```bash
+php artisan env:decrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--force] [--path [PATH]] [--filename [FILENAME]]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be decrypted
+- `--filename` (value optional) — Filename of the decrypted file
+- `--force` — Overwrite the existing environment file
+- `--key` (value optional) — The encryption key
+- `--path` (value optional) — Path to write the decrypted file
+
+Source: https://artisan.page/13.x/envdecrypt.md
+
+### `php artisan env:encrypt`
+
+Encrypt an environment file
+
+```bash
+php artisan env:encrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--readable] [--prune] [--force]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be encrypted
+- `--force` — Overwrite the existing encrypted environment file
+- `--key` (value optional) — The encryption key
+- `--prune` — Delete the original environment file
+- `--readable` — Encrypt each variable individually with readable, plain-text variable names
+
+Source: https://artisan.page/13.x/envencrypt.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/13.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/13.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/13.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]] [--json]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+- `--json` — Output the events and listeners as JSON
+
+Source: https://artisan.page/13.x/eventlist.md
+
+### `php artisan fortify:install`
+
+Install all of the Fortify resources
+
+```bash
+php artisan fortify:install
+```
+
+Source: https://artisan.page/13.x/fortifyinstall.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/13.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/13.x/horizon.md
+
+### `php artisan horizon:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan horizon:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/13.x/horizonclear.md
+
+### `php artisan horizon:clear-metrics`
+
+Delete metrics for all jobs and queues
+
+```bash
+php artisan horizon:clear-metrics
+```
+
+Source: https://artisan.page/13.x/horizonclear-metrics.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/13.x/horizoncontinue.md
+
+### `php artisan horizon:continue-supervisor`
+
+Instruct the supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to resume
+
+Source: https://artisan.page/13.x/horizoncontinue-supervisor.md
+
+### `php artisan horizon:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan horizon:forget [--all] [--] [<id>]
+```
+
+Arguments:
+- `id` — The ID of the failed job
+
+Options:
+- `--all` — Delete all failed jobs
+
+Source: https://artisan.page/13.x/horizonforget.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/13.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/13.x/horizonlist.md
+
+### `php artisan horizon:listen`
+
+Run Horizon and automatically restart workers on file changes
+
+```bash
+php artisan horizon:listen [--environment [ENVIRONMENT]] [--poll]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+- `--poll` — Use polling for file watching
+
+Source: https://artisan.page/13.x/horizonlisten.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/13.x/horizonpause.md
+
+### `php artisan horizon:pause-supervisor`
+
+Pause a supervisor
+
+```bash
+php artisan horizon:pause-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to pause
+
+Source: https://artisan.page/13.x/horizonpause-supervisor.md
+
+### `php artisan horizon:publish`
+
+Publish all of the Horizon resources
+
+```bash
+php artisan horizon:publish
+```
+
+Source: https://artisan.page/13.x/horizonpublish.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge [--signal [SIGNAL]]
+```
+
+Options:
+- `--signal` (value optional) — The signal to send to the rogue processes; default: `SIGTERM`
+
+Source: https://artisan.page/13.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/13.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/13.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--auto-scaling-strategy [AUTO-SCALING-STRATEGY]] [--balance-cooldown [BALANCE-COOLDOWN]] [--balance-max-shift [BALANCE-MAX-SHIFT]] [--workers-name [WORKERS-NAME]] [--parent-id [PARENT-ID]] [--rest [REST]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--auto-scaling-strategy` (value optional) — If supervisor should scale by jobs or time to complete; default: `time`
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--balance-cooldown` (value optional) — The number of seconds to wait in between auto-scaling attempts; default: `3`
+- `--balance-max-shift` (value optional) — The maximum number of processes to increase or decrease per one scaling; default: `1`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping a child process; default: `0`
+- `--max-processes` (value optional) — The maximum number of total workers to start; default: `1`
+- `--max-time` (value optional) — The maximum number of seconds a child process should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue; default: `1`
+- `--nice` (value optional) — The process priority; default: `0`
+- `--parent-id` (value optional) — The parent process ID; default: `0`
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+- `--workers-name` (value optional) — The name that should be assigned to the workers; default: `default`
+
+Source: https://artisan.page/13.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisor-status`
+
+Show the status for a given supervisor
+
+```bash
+php artisan horizon:supervisor-status <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor
+
+Source: https://artisan.page/13.x/horizonsupervisor-status.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/13.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/13.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/13.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--stop-when-empty-for [STOP-WHEN-EMPTY-FOR]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--json] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--json` — Output the queue worker information as JSON
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--stop-when-empty-for` (value optional) — Stop when no jobs have been processed for the given number of seconds; default: `0`
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/13.x/horizonwork.md
+
+### `php artisan inertia:check-ssr`
+
+Check the Inertia SSR server health status
+
+```bash
+php artisan inertia:check-ssr
+```
+
+Source: https://artisan.page/13.x/inertiacheck-ssr.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/13.x/inertiamiddleware.md
+
+### `php artisan inertia:start-ssr`
+
+Start the Inertia SSR server
+
+```bash
+php artisan inertia:start-ssr [--runtime [RUNTIME]]
+```
+
+Options:
+- `--runtime` (value optional) — The runtime to use (e.g. `node`, `bun`, or an absolute path)
+
+Source: https://artisan.page/13.x/inertiastart-ssr.md
+
+### `php artisan inertia:stop-ssr`
+
+Stop the Inertia SSR server
+
+```bash
+php artisan inertia:stop-ssr
+```
+
+Source: https://artisan.page/13.x/inertiastop-ssr.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/13.x/inspire.md
+
+### `php artisan install:api`
+
+Create an API routes file and install Laravel Sanctum or Laravel Passport
+
+```bash
+php artisan install:api [--composer [COMPOSER]] [--force] [--passport] [--without-migration-prompt]
+```
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--force` — Overwrite any existing API routes file
+- `--passport` — Install Laravel Passport instead of Laravel Sanctum
+- `--without-migration-prompt` — Do not prompt to run pending migrations
+
+Source: https://artisan.page/13.x/installapi.md
+
+### `php artisan install:broadcasting`
+
+Create a broadcasting channel routes file
+
+```bash
+php artisan install:broadcasting [--composer [COMPOSER]] [--force] [--without-reverb] [--reverb] [--pusher] [--ably] [--without-node]
+```
+
+Options:
+- `--ably` — Install Ably as the default broadcaster
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--force` — Overwrite any existing broadcasting routes file
+- `--pusher` — Install Pusher as the default broadcaster
+- `--reverb` — Install Laravel Reverb as the default broadcaster
+- `--without-node` — Do not prompt to install Node dependencies
+- `--without-reverb` — Do not prompt to install Laravel Reverb
+
+Source: https://artisan.page/13.x/installbroadcasting.md
+
+### `php artisan invoke-serialized-closure`
+
+Invoke the given serialized closure
+
+```bash
+php artisan invoke-serialized-closure [<code>]
+```
+
+Arguments:
+- `code` — The serialized closure
+
+Source: https://artisan.page/13.x/invoke-serialized-closure.md
+
+### `php artisan jetstream:install`
+
+Install the Jetstream components and resources
+
+```bash
+php artisan jetstream:install [--dark] [--teams] [--api] [--verification] [--pest] [--ssr] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (inertia,livewire)
+
+Options:
+- `--api` — Indicates if API support should be installed
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--pest` — Indicates if Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--teams` — Indicates if team support should be installed
+- `--verification` — Indicates if email verification support should be installed
+
+Source: https://artisan.page/13.x/jetstreaminstall.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/13.x/keygenerate.md
+
+### `php artisan lang:publish`
+
+Publish all language files that are available for customization
+
+```bash
+php artisan lang:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/13.x/langpublish.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--short] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+- `--short` — To skip describing commands' arguments
+
+Source: https://artisan.page/13.x/list.md
+
+### `php artisan livewire:attribute`
+
+Create a new Livewire attribute class
+
+```bash
+php artisan livewire:attribute [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/13.x/livewireattribute.md
+
+### `php artisan livewire:config`
+
+Publish Livewire config file
+
+```bash
+php artisan livewire:config
+```
+
+Source: https://artisan.page/13.x/livewireconfig.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/13.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:convert`
+
+Convert a Livewire component between single-file and multi-file formats
+
+```bash
+php artisan livewire:convert [--sfc] [--mfc] [--test] [--emoji EMOJI] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--mfc` — Convert to multi-file component
+- `--sfc` — Convert to single-file component
+- `--test` — Create a test file when converting to multi-file (if one does not exist)
+
+Source: https://artisan.page/13.x/livewireconvert.md
+
+### `php artisan livewire:form`
+
+Create a new Livewire form class
+
+```bash
+php artisan livewire:form [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/13.x/livewireform.md
+
+### `php artisan livewire:layout`
+
+Create a new app layout file
+
+```bash
+php artisan livewire:layout [--force] [--stub [STUB]]
+```
+
+Options:
+- `--force`
+- `--stub` (value optional) — If you have several stubs, stored in subfolders
+
+Source: https://artisan.page/13.x/livewirelayout.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/13.x/livewiremake.md
+
+### `php artisan livewire:publish`
+
+Publish Livewire configuration
+
+```bash
+php artisan livewire:publish [--assets] [--config] [--pagination]
+```
+
+Options:
+- `--assets` — Indicates if Livewire's front-end assets should be published
+- `--config` — Indicates if Livewire's config file should be published
+- `--pagination` — Indicates if Livewire's pagination views should be published
+
+Source: https://artisan.page/13.x/livewirepublish.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/13.x/livewirestubs.md
+
+### `php artisan make:cache-table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan make:cache-table
+```
+
+Aliases: `cache:table`
+
+Source: https://artisan.page/13.x/makecache-table.md
+
+### `php artisan make:cast`
+
+Create a new custom Eloquent cast class
+
+```bash
+php artisan make:cast [-f|--force] [--inbound] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the cast
+
+Options:
+- `--force` — Create the class even if the cast already exists
+- `--inbound` — Generate an inbound cast class
+
+Source: https://artisan.page/13.x/makecast.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the channel
+
+Options:
+- `--force` — Create the class even if the channel already exists
+
+Source: https://artisan.page/13.x/makechannel.md
+
+### `php artisan make:class`
+
+Create a new class
+
+```bash
+php artisan make:class [-i|--invokable] [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the class already exists
+- `--invokable` — Generate a single method, invokable class
+
+Source: https://artisan.page/13.x/makeclass.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [-f|--force] [--command [COMMAND]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that will be used to invoke the class
+- `--force` — Create the class even if the console command already exists
+- `--pest` — Generate an accompanying Pest test for the Console command
+- `--phpunit` — Generate an accompanying PHPUnit test for the Console command
+- `--test` — Generate an accompanying Test test for the Console command
+
+Source: https://artisan.page/13.x/makecommand.md
+
+### `php artisan make:component`
+
+Create a new view component class
+
+```bash
+php artisan make:component [--inline] [--view] [--path PATH] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--force` — Create the class even if the component already exists
+- `--inline` — Create a component that renders an inline view
+- `--path` (value required) — The location where the component view should be created
+- `--pest` — Generate an accompanying Pest test for the Component
+- `--phpunit` — Generate an accompanying PHPUnit test for the Component
+- `--test` — Generate an accompanying Test test for the Component
+- `--view` — Create an anonymous component with only a view
+
+Source: https://artisan.page/13.x/makecomponent.md
+
+### `php artisan make:config`
+
+Create a new configuration file
+
+```bash
+php artisan make:config [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the config
+
+Options:
+- `--force` — Create the configuration file even if it already exists
+
+Aliases: `config:make`
+
+Source: https://artisan.page/13.x/makeconfig.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--type TYPE] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [-R|--requests] [-s|--singleton] [--creatable] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the controller
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller
+- `--creatable` — Indicate that a singleton resource should be creatable
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class
+- `--model` (value optional) — Generate a resource controller for the given model
+- `--parent` (value optional) — Generate a nested resource controller class
+- `--pest` — Generate an accompanying Pest test for the Controller
+- `--phpunit` — Generate an accompanying PHPUnit test for the Controller
+- `--requests` — Generate FormRequest classes for store and update
+- `--resource` — Generate a resource controller class
+- `--singleton` — Generate a singleton resource controller class
+- `--test` — Generate an accompanying Test test for the Controller
+- `--type` (value required) — Manually specify the controller stub file to use
+
+Source: https://artisan.page/13.x/makecontroller.md
+
+### `php artisan make:enum`
+
+Create a new enum
+
+```bash
+php artisan make:enum [-s|--string] [-i|--int] [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the enum
+
+Options:
+- `--force` — Create the enum even if the enum already exists
+- `--int` — Generate an integer backed enum.
+- `--string` — Generate a string backed enum.
+
+Source: https://artisan.page/13.x/makeenum.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the event
+
+Options:
+- `--force` — Create the class even if the event already exists
+
+Source: https://artisan.page/13.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [-f|--force] [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the exception
+
+Options:
+- `--force` — Create the class even if the exception already exists
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/13.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the factory
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/13.x/makefactory.md
+
+### `php artisan make:interface`
+
+Create a new interface
+
+```bash
+php artisan make:interface [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the interface
+
+Options:
+- `--force` — Create the interface even if the interface already exists
+
+Source: https://artisan.page/13.x/makeinterface.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [-f|--force] [--sync] [--batched] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the job
+
+Options:
+- `--batched` — Indicates that the job should be batchable
+- `--force` — Create the class even if the job already exists
+- `--pest` — Generate an accompanying Pest test for the Job
+- `--phpunit` — Generate an accompanying PHPUnit test for the Job
+- `--sync` — Indicates that the job should be synchronous
+- `--test` — Generate an accompanying Test test for the Job
+
+Source: https://artisan.page/13.x/makejob.md
+
+### `php artisan make:job-middleware`
+
+Create a new job middleware class
+
+```bash
+php artisan make:job-middleware [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--force` — Create the class even if the job middleware already exists
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--phpunit` — Generate an accompanying PHPUnit test for the Middleware
+- `--test` — Generate an accompanying Test test for the Middleware
+
+Source: https://artisan.page/13.x/makejob-middleware.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [-f|--force] [--queued] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the listener
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--force` — Create the class even if the listener already exists
+- `--pest` — Generate an accompanying Pest test for the Listener
+- `--phpunit` — Generate an accompanying PHPUnit test for the Listener
+- `--queued` — Indicates the event listener should be queued
+- `--test` — Generate an accompanying Test test for the Listener
+
+Source: https://artisan.page/13.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/13.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--view [VIEW]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the mailable
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+- `--pest` — Generate an accompanying Pest test for the Mailable
+- `--phpunit` — Generate an accompanying PHPUnit test for the Mailable
+- `--test` — Generate an accompanying Test test for the Mailable
+- `--view` (value optional) — Create a new Blade template for the mailable
+
+Source: https://artisan.page/13.x/makemail.md
+
+### `php artisan make:mcp-app-resource`
+
+Create a new MCP app resource class and linked view
+
+```bash
+php artisan make:mcp-app-resource [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the appresource
+
+Options:
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/13.x/makemcp-app-resource.md
+
+### `php artisan make:mcp-prompt`
+
+Create a new MCP prompt class
+
+```bash
+php artisan make:mcp-prompt [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the prompt
+
+Options:
+- `--force` — Create the class even if the prompt already exists
+
+Source: https://artisan.page/13.x/makemcp-prompt.md
+
+### `php artisan make:mcp-resource`
+
+Create a new MCP resource class
+
+```bash
+php artisan make:mcp-resource [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/13.x/makemcp-resource.md
+
+### `php artisan make:mcp-server`
+
+Create a new MCP server class
+
+```bash
+php artisan make:mcp-server [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the server
+
+Options:
+- `--force` — Create the class even if the server already exists
+
+Source: https://artisan.page/13.x/makemcp-server.md
+
+### `php artisan make:mcp-tool`
+
+Create a new MCP tool class
+
+```bash
+php artisan make:mcp-tool [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the tool
+
+Options:
+- `--force` — Create the class even if the tool already exists
+
+Source: https://artisan.page/13.x/makemcp-tool.md
+
+### `php artisan make:middleware`
+
+Create a new HTTP middleware class
+
+```bash
+php artisan make:middleware [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--phpunit` — Generate an accompanying PHPUnit test for the Middleware
+- `--test` — Generate an accompanying Test test for the Middleware
+
+Source: https://artisan.page/13.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration (Deprecated)
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/13.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [--morph-pivot] [--policy] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [-R|--requests] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the model
+
+Options:
+- `--all` — Generate a migration, seeder, factory, policy, resource controller, and form request classes for the model
+- `--api` — Indicates if the generated controller should be an API resource controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--morph-pivot` — Indicates if the generated model should be a custom polymorphic intermediate table model
+- `--pest` — Generate an accompanying Pest test for the Model
+- `--phpunit` — Generate an accompanying PHPUnit test for the Model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--policy` — Create a new policy for the model
+- `--requests` — Create new form request classes and use them in the resource controller
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder for the model
+- `--test` — Generate an accompanying Test test for the Model
+
+Source: https://artisan.page/13.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the notification
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+- `--pest` — Generate an accompanying Pest test for the Notification
+- `--phpunit` — Generate an accompanying PHPUnit test for the Notification
+- `--test` — Generate an accompanying Test test for the Notification
+
+Source: https://artisan.page/13.x/makenotification.md
+
+### `php artisan make:notifications-table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan make:notifications-table
+```
+
+Aliases: `notifications:table`
+
+Source: https://artisan.page/13.x/makenotifications-table.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-f|--force] [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the observer
+
+Options:
+- `--force` — Create the class even if the observer already exists
+- `--model` (value optional) — The model that the observer applies to
+
+Source: https://artisan.page/13.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-f|--force] [-m|--model [MODEL]] [-g|--guard [GUARD]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--guard` (value optional) — The guard that the policy relies on
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/13.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the provider
+
+Options:
+- `--force` — Create the class even if the provider already exists
+
+Source: https://artisan.page/13.x/makeprovider.md
+
+### `php artisan make:queue-batches-table`
+
+Create a migration for the batches database table
+
+```bash
+php artisan make:queue-batches-table
+```
+
+Aliases: `queue:batches-table`
+
+Source: https://artisan.page/13.x/makequeue-batches-table.md
+
+### `php artisan make:queue-failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan make:queue-failed-table
+```
+
+Aliases: `queue:failed-table`
+
+Source: https://artisan.page/13.x/makequeue-failed-table.md
+
+### `php artisan make:queue-table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan make:queue-table
+```
+
+Aliases: `queue:table`
+
+Source: https://artisan.page/13.x/makequeue-table.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the request
+
+Options:
+- `--force` — Create the class even if the request already exists
+
+Source: https://artisan.page/13.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-f|--force] [-j|--json-api] [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--collection` — Create a resource collection
+- `--force` — Create the class even if the resource already exists
+- `--json-api` — Create a JSON:API resource
+
+Source: https://artisan.page/13.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule [-f|--force] [-i|--implicit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the rule
+
+Options:
+- `--force` — Create the class even if the rule already exists
+- `--implicit` — Generate an implicit rule
+
+Source: https://artisan.page/13.x/makerule.md
+
+### `php artisan make:scope`
+
+Create a new scope class
+
+```bash
+php artisan make:scope [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the scope
+
+Options:
+- `--force` — Create the class even if the scope already exists
+
+Source: https://artisan.page/13.x/makescope.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the seeder
+
+Source: https://artisan.page/13.x/makeseeder.md
+
+### `php artisan make:session-table`
+
+Create a migration for the session database table
+
+```bash
+php artisan make:session-table
+```
+
+Aliases: `session:table`
+
+Source: https://artisan.page/13.x/makesession-table.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [-f|--force] [-u|--unit] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the test
+
+Options:
+- `--force` — Create the test even if the test already exists
+- `--pest` — Create a Pest test
+- `--phpunit` — Create a PHPUnit test
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/13.x/maketest.md
+
+### `php artisan make:trait`
+
+Create a new trait
+
+```bash
+php artisan make:trait [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the trait
+
+Options:
+- `--force` — Create the trait even if the trait already exists
+
+Source: https://artisan.page/13.x/maketrait.md
+
+### `php artisan make:view`
+
+Create a new view
+
+```bash
+php artisan make:view [--extension [EXTENSION]] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the view
+
+Options:
+- `--extension` (value optional) — The extension of the generated view; default: `blade.php`
+- `--force` — Create the view even if the view already exists
+- `--pest` — Generate an accompanying Pest test for the View
+- `--phpunit` — Generate an accompanying PHPUnit test for the View
+- `--test` — Generate an accompanying Test test for the View
+
+Source: https://artisan.page/13.x/makeview.md
+
+### `php artisan make:volt`
+
+Create a new Volt component
+
+```bash
+php artisan make:volt [--class] [--functional] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the volt component
+
+Options:
+- `--class` — Create a class based component
+- `--force` — Create the Volt component even if the component already exists
+- `--functional` — Create a functional component
+- `--pest` — Generate an accompanying Pest test for the Volt component
+- `--phpunit` — Generate an accompanying PHPUnit test for the Volt component
+- `--test` — Generate an accompanying Test test for the Volt component
+
+Source: https://artisan.page/13.x/makevolt.md
+
+### `php artisan mcp:inspector`
+
+Open the MCP Inspector tool to debug and test MCP Servers
+
+```bash
+php artisan mcp:inspector [--host [HOST]] [--port [PORT]] [--] <handle>
+```
+
+Arguments:
+- `handle` (required) — The handle or route of the MCP server to inspect.
+
+Options:
+- `--host` (value optional) — The host the inspector should bind to
+- `--port` (value optional) — The port the inspector should bind to
+
+Source: https://artisan.page/13.x/mcpinspector.md
+
+### `php artisan mcp:start`
+
+Start the MCP Server for a given handle
+
+```bash
+php artisan mcp:start <handle>
+```
+
+Arguments:
+- `handle` (required) — The handle of the MCP server to start.
+
+Source: https://artisan.page/13.x/mcpstart.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--pretend] [--seed] [--seeder [SEEDER]] [--step] [--graceful] [--isolated [ISOLATED]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--graceful` — Return a successful exit code even if an error occurs
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/13.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/13.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/13.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/13.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/13.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]] [--batch BATCH]
+```
+
+Options:
+- `--batch` (value required) — The batch of migrations (identified by their batch number) to be reverted
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/13.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--pending [PENDING]] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--pending` (value optional) — Only list pending migrations
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/13.x/migratestatus.md
+
+### `php artisan model:prune`
+
+Prune models that are no longer needed
+
+```bash
+php artisan model:prune [--model [MODEL]] [--except [EXCEPT]] [--path [PATH]] [--chunk [CHUNK]] [--pretend]
+```
+
+Options:
+- `--chunk` (value optional) — The number of models to retrieve per chunk of models to be deleted; default: `1000`
+- `--except` (value optional) — Class names of the models to be excluded from pruning
+- `--model` (value optional) — Class names of the models to be pruned
+- `--path` (value optional) — Absolute path(s) to directories where models are located
+- `--pretend` — Display the number of prunable records found instead of deleting them
+
+Source: https://artisan.page/13.x/modelprune.md
+
+### `php artisan model:show`
+
+Show information about an Eloquent model
+
+```bash
+php artisan model:show [--database [DATABASE]] [--json] [--] <model>
+```
+
+Arguments:
+- `model` (required) — The model to show
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--json` — Output the model as JSON
+
+Source: https://artisan.page/13.x/modelshow.md
+
+### `php artisan nightwatch:agent`
+
+Run the Nightwatch agent.
+
+```bash
+php artisan nightwatch:agent [--listen-on [LISTEN-ON]] [--auth-connection-timeout [AUTH-CONNECTION-TIMEOUT]] [--auth-timeout [AUTH-TIMEOUT]] [--ingest-connection-timeout [INGEST-CONNECTION-TIMEOUT]] [--ingest-timeout [INGEST-TIMEOUT]] [--server [SERVER]] [--silent]
+```
+
+Options:
+- `--auth-connection-timeout` (value optional)
+- `--auth-timeout` (value optional)
+- `--ingest-connection-timeout` (value optional)
+- `--ingest-timeout` (value optional)
+- `--listen-on` (value optional)
+- `--server` (value optional)
+- `--silent` — Do not output any message
+
+Source: https://artisan.page/13.x/nightwatchagent.md
+
+### `php artisan nightwatch:deploy`
+
+Send deployment metadata to Nightwatch.
+
+```bash
+php artisan nightwatch:deploy [--ref [REF]] [--name [NAME]] [--url [URL]] [--timestamp [TIMESTAMP]] [--] [<deploy>]
+```
+
+Arguments:
+- `deploy` — A unique value for the deploy <comment>[default: `NIGHTWATCH_DEPLOY`]</comment>
+
+Options:
+- `--name` (value optional) — The human-readable name of the deploy
+- `--ref` (value optional) — The git ref (tag or hash) of the deploy
+- `--timestamp` (value optional) — The timestamp of the deploy <comment>[default: `now()`]</comment>
+- `--url` (value optional) — A URL with information related to the deploy
+
+Source: https://artisan.page/13.x/nightwatchdeploy.md
+
+### `php artisan nightwatch:status`
+
+Get the current status of the Nightwatch agent.
+
+```bash
+php artisan nightwatch:status
+```
+
+Source: https://artisan.page/13.x/nightwatchstatus.md
+
+### `php artisan nova:action`
+
+Create a new action class
+
+```bash
+php artisan nova:action [--destructive] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the action
+
+Options:
+- `--destructive` — Indicate that the action deletes / destroys resources
+- `--queued` — Indicates the action should be queued
+
+Source: https://artisan.page/13.x/novaaction.md
+
+### `php artisan nova:asset`
+
+Create a new asset
+
+```bash
+php artisan nova:asset <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/13.x/novaasset.md
+
+### `php artisan nova:base-resource`
+
+Create a new base resource class
+
+```bash
+php artisan nova:base-resource <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Source: https://artisan.page/13.x/novabase-resource.md
+
+### `php artisan nova:card`
+
+Create a new card
+
+```bash
+php artisan nova:card <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/13.x/novacard.md
+
+### `php artisan nova:check-license`
+
+Verify your Nova license key
+
+```bash
+php artisan nova:check-license
+```
+
+Source: https://artisan.page/13.x/novacheck-license.md
+
+### `php artisan nova:custom-filter`
+
+Create a new custom filter
+
+```bash
+php artisan nova:custom-filter <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/13.x/novacustom-filter.md
+
+### `php artisan nova:dashboard`
+
+Create a new dashboard.
+
+```bash
+php artisan nova:dashboard <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/13.x/novadashboard.md
+
+### `php artisan nova:field`
+
+Create a new field
+
+```bash
+php artisan nova:field <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/13.x/novafield.md
+
+### `php artisan nova:filter`
+
+Create a new filter class
+
+```bash
+php artisan nova:filter [--boolean] [--date] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the filter
+
+Options:
+- `--boolean` — Indicates if the generated filter should be a boolean filter
+- `--date` — Indicates if the generated filter should be a date filter
+
+Source: https://artisan.page/13.x/novafilter.md
+
+### `php artisan nova:install`
+
+Install all of the Nova resources
+
+```bash
+php artisan nova:install
+```
+
+Source: https://artisan.page/13.x/novainstall.md
+
+### `php artisan nova:lens`
+
+Create a new lens class
+
+```bash
+php artisan nova:lens <name>
+```
+
+Arguments:
+- `name` (required) — The name of the lens
+
+Source: https://artisan.page/13.x/novalens.md
+
+### `php artisan nova:partition`
+
+Create a new metric (partition) class
+
+```bash
+php artisan nova:partition <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/13.x/novapartition.md
+
+### `php artisan nova:policy`
+
+Create a new policy class
+
+```bash
+php artisan nova:policy [-f|--force] [-m|--resource [RESOURCE]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--resource` (value optional) — The resource that the policy applies to
+
+Source: https://artisan.page/13.x/novapolicy.md
+
+### `php artisan nova:progress`
+
+Create a new metric (progress) class
+
+```bash
+php artisan nova:progress <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/13.x/novaprogress.md
+
+### `php artisan nova:publish`
+
+Publish all of the Nova resources
+
+```bash
+php artisan nova:publish [-f|--force] [--fortify|--no-fortify]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+- `--fortify` — Publish Laravel Fortify features
+
+Source: https://artisan.page/13.x/novapublish.md
+
+### `php artisan nova:repeatable`
+
+Create a new repeatable class
+
+```bash
+php artisan nova:repeatable [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the repeatable
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/13.x/novarepeatable.md
+
+### `php artisan nova:resource`
+
+Create a new resource class
+
+```bash
+php artisan nova:resource [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/13.x/novaresource.md
+
+### `php artisan nova:resource-tool`
+
+Create a new resource tool
+
+```bash
+php artisan nova:resource-tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/13.x/novaresource-tool.md
+
+### `php artisan nova:stubs`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan nova:stubs [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/13.x/novastubs.md
+
+### `php artisan nova:table`
+
+Create a new metric (table) class
+
+```bash
+php artisan nova:table <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/13.x/novatable.md
+
+### `php artisan nova:tool`
+
+Create a new tool
+
+```bash
+php artisan nova:tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/13.x/novatool.md
+
+### `php artisan nova:translate`
+
+Create translation files for Nova
+
+```bash
+php artisan nova:translate [--force] [--] <language>
+```
+
+Arguments:
+- `language` (required)
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/13.x/novatranslate.md
+
+### `php artisan nova:trend`
+
+Create a new metric (trend) class
+
+```bash
+php artisan nova:trend <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/13.x/novatrend.md
+
+### `php artisan nova:user`
+
+Create a new user
+
+```bash
+php artisan nova:user
+```
+
+Source: https://artisan.page/13.x/novauser.md
+
+### `php artisan nova:value`
+
+Create a new metric (single value) class
+
+```bash
+php artisan nova:value <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/13.x/novavalue.md
+
+### `php artisan octane:frankenphp`
+
+Start the Octane FrankenPHP server
+
+```bash
+php artisan octane:frankenphp [--host [HOST]] [--port [PORT]] [--admin-host [ADMIN-HOST]] [--admin-port [ADMIN-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-host` (value optional) — The host the admin server should be available on; default: `localhost`
+- `--admin-port` (value optional) — The port the admin server should be available on; default: `2019`
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to; default: `127.0.0.1`
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed)
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/13.x/octanefrankenphp.md
+
+### `php artisan octane:install`
+
+Install the Octane components and resources
+
+```bash
+php artisan octane:install [--server [SERVER]] [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing configuration files
+- `--server` (value optional) — The server that should be used to serve the application
+
+Source: https://artisan.page/13.x/octaneinstall.md
+
+### `php artisan octane:reload`
+
+Reload the Octane workers
+
+```bash
+php artisan octane:reload [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/13.x/octanereload.md
+
+### `php artisan octane:roadrunner`
+
+Start the Octane RoadRunner server
+
+```bash
+php artisan octane:roadrunner [--host [HOST]] [--port [PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/13.x/octaneroadrunner.md
+
+### `php artisan octane:start`
+
+Start the Octane server
+
+```bash
+php artisan octane:start [--server [SERVER]] [--host [HOST]] [--port [PORT]] [--admin-port [ADMIN-PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-port` (value optional) — The port the admin server should be available on [FrankenPHP only]
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed) [FrankenPHP only]
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on [default: "8000"]
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--server` (value optional) — The server that should be used to serve the application
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests
+
+Source: https://artisan.page/13.x/octanestart.md
+
+### `php artisan octane:status`
+
+Get the current status of the Octane server
+
+```bash
+php artisan octane:status [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/13.x/octanestatus.md
+
+### `php artisan octane:stop`
+
+Stop the Octane server
+
+```bash
+php artisan octane:stop [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/13.x/octanestop.md
+
+### `php artisan octane:swoole`
+
+Start the Octane Swoole server
+
+```bash
+php artisan octane:swoole [--host [HOST]] [--port [PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--watch] [--poll]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks; default: `auto`
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/13.x/octaneswoole.md
+
+### `php artisan optimize`
+
+Cache framework bootstrap, configuration, and metadata to increase performance
+
+```bash
+php artisan optimize [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — Do not run the commands matching the key or name
+
+Source: https://artisan.page/13.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — The commands to skip
+
+Source: https://artisan.page/13.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/13.x/packagediscover.md
+
+### `php artisan pail`
+
+Tails the application logs
+
+```bash
+php artisan pail [--filter [FILTER]] [--message [MESSAGE]] [--level [LEVEL]] [--auth [AUTH]] [--user [USER]] [--timeout [TIMEOUT]]
+```
+
+Options:
+- `--auth` (value optional) — Filter the logs by the given authenticated ID
+- `--filter` (value optional) — Filter the logs by the given value
+- `--level` (value optional) — Filter the logs by the given level
+- `--message` (value optional) — Filter the logs by the given message
+- `--timeout` (value optional) — The maximum execution time in seconds; default: `3600`
+- `--user` (value optional) — Filter the logs by the given authenticated ID (alias for --auth)
+
+Source: https://artisan.page/13.x/pail.md
+
+### `php artisan passport:client`
+
+Create a client for issuing access tokens
+
+```bash
+php artisan passport:client [--personal] [--password] [--client] [--implicit] [--device] [--name [NAME]] [--provider [PROVIDER]] [--redirect_uri [REDIRECT_URI]] [--public]
+```
+
+Options:
+- `--client` — Create a client credentials grant client
+- `--device` — Create a device authorization grant client
+- `--implicit` — Create an implicit grant client
+- `--name` (value optional) — The name of the client
+- `--password` — Create a password grant client
+- `--personal` — Create a personal access token client
+- `--provider` (value optional) — The name of the user provider
+- `--public` — Create a public client (without secret)
+- `--redirect_uri` (value optional) — The URI to redirect to after authorization
+
+Source: https://artisan.page/13.x/passportclient.md
+
+### `php artisan passport:hash`
+
+Hash all of the existing secrets in the clients table
+
+```bash
+php artisan passport:hash [--force]
+```
+
+Options:
+- `--force` — Force the operation to run without confirmation prompt
+
+Source: https://artisan.page/13.x/passporthash.md
+
+### `php artisan passport:install`
+
+Run the commands necessary to prepare Passport for use
+
+```bash
+php artisan passport:install [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/13.x/passportinstall.md
+
+### `php artisan passport:keys`
+
+Create the encryption keys for API authentication
+
+```bash
+php artisan passport:keys [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/13.x/passportkeys.md
+
+### `php artisan passport:purge`
+
+Purge revoked and / or expired tokens and authentication codes
+
+```bash
+php artisan passport:purge [--revoked] [--expired] [--hours [HOURS]]
+```
+
+Options:
+- `--expired` — Only purge expired tokens and authentication codes
+- `--hours` (value optional) — The number of hours to retain expired tokens; default: `168`
+- `--revoked` — Only purge revoked tokens and authentication codes
+
+Source: https://artisan.page/13.x/passportpurge.md
+
+### `php artisan pennant:feature`
+
+Create a new feature class
+
+```bash
+php artisan pennant:feature [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the feature
+
+Options:
+- `--force` — Create the class even if the feature already exists
+
+Source: https://artisan.page/13.x/pennantfeature.md
+
+### `php artisan pennant:purge`
+
+Delete Pennant features from storage
+
+```bash
+php artisan pennant:purge [--except [EXCEPT]] [--except-registered] [--store [STORE]] [--] [<features>...]
+```
+
+Arguments:
+- `features` — The features to purge
+
+Options:
+- `--except` (value optional) — The features that should be excluded from purging
+- `--except-registered` — Purge all features except those registered
+- `--store` (value optional) — The store to purge the features from
+
+Aliases: `pennant:clear`
+
+Source: https://artisan.page/13.x/pennantpurge.md
+
+### `php artisan pulse:check`
+
+Take a snapshot of the current server's pulse
+
+```bash
+php artisan pulse:check [--once]
+```
+
+Options:
+- `--once` — Take a single snapshot
+
+Source: https://artisan.page/13.x/pulsecheck.md
+
+### `php artisan pulse:clear`
+
+Delete all Pulse data from storage
+
+```bash
+php artisan pulse:clear [--type [TYPE]] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--type` (value optional) — Only clear the specified type(s)
+
+Aliases: `pulse:purge`
+
+Source: https://artisan.page/13.x/pulseclear.md
+
+### `php artisan pulse:restart`
+
+Restart any running "work" and "check" commands
+
+```bash
+php artisan pulse:restart
+```
+
+Source: https://artisan.page/13.x/pulserestart.md
+
+### `php artisan pulse:work`
+
+Process incoming Pulse data from the ingest stream
+
+```bash
+php artisan pulse:work [--stop-when-empty]
+```
+
+Options:
+- `--stop-when-empty` — Stop when the stream is empty
+
+Source: https://artisan.page/13.x/pulsework.md
+
+### `php artisan queue:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan queue:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to clear
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/13.x/queueclear.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed [--json]
+```
+
+Options:
+- `--json` — Output the failed jobs as JSON
+
+Source: https://artisan.page/13.x/queuefailed.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed job data
+
+Source: https://artisan.page/13.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/13.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--queue` (value optional) — The queue to listen on
+- `--rest` (value optional) — The number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — The number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — The number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/13.x/queuelisten.md
+
+### `php artisan queue:monitor`
+
+Monitor the size of the specified queues
+
+```bash
+php artisan queue:monitor [--max [MAX]] [--json] [--] <queues>
+```
+
+Arguments:
+- `queues` (required) — The names of the queues to monitor
+
+Options:
+- `--json` — Output the queue size as JSON
+- `--max` (value optional) — The maximum number of jobs that can be on the queue before an event is dispatched; default: `1000`
+
+Source: https://artisan.page/13.x/queuemonitor.md
+
+### `php artisan queue:pause`
+
+Pause job processing for a specific queue
+
+```bash
+php artisan queue:pause <queue>
+```
+
+Arguments:
+- `queue` (required) — The name of the queue to pause
+
+Source: https://artisan.page/13.x/queuepause.md
+
+### `php artisan queue:prune-batches`
+
+Prune stale entries from the batches database
+
+```bash
+php artisan queue:prune-batches [--hours [HOURS]] [--unfinished [UNFINISHED]] [--cancelled [CANCELLED]]
+```
+
+Options:
+- `--cancelled` (value optional) — The number of hours to retain cancelled batch data
+- `--hours` (value optional) — The number of hours to retain batch data; default: `24`
+- `--unfinished` (value optional) — The number of hours to retain unfinished batch data
+
+Source: https://artisan.page/13.x/queueprune-batches.md
+
+### `php artisan queue:prune-failed`
+
+Prune stale entries from the failed jobs table
+
+```bash
+php artisan queue:prune-failed [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed jobs data; default: `24`
+
+Source: https://artisan.page/13.x/queueprune-failed.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/13.x/queuerestart.md
+
+### `php artisan queue:resume`
+
+Resume job processing for a paused queue
+
+```bash
+php artisan queue:resume <queue>
+```
+
+Arguments:
+- `queue` (required) — The name of the queue that should resume processing
+
+Aliases: `queue:continue`
+
+Source: https://artisan.page/13.x/queueresume.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry [--queue [QUEUE]] [--range [RANGE]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the failed job or "all" to retry all jobs
+
+Options:
+- `--queue` (value optional) — Retry all of the failed jobs for the specified queue
+- `--range` (value optional) — Range of job IDs (numeric) to be retried (e.g. 1-5)
+
+Source: https://artisan.page/13.x/queueretry.md
+
+### `php artisan queue:retry-batch`
+
+Retry the failed jobs for a batch
+
+```bash
+php artisan queue:retry-batch [--isolated [ISOLATED]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the batch whose failed jobs should be retried
+
+Options:
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+
+Source: https://artisan.page/13.x/queueretry-batch.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--name [NAME]] [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--stop-when-empty-for [STOP-WHEN-EMPTY-FOR]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--json] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--json` — Output the queue worker information as JSON
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — The number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — The number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--stop-when-empty-for` (value optional) — Stop when no jobs have been processed for the given number of seconds; default: `0`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — The number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/13.x/queuework.md
+
+### `php artisan reload`
+
+Reload running services
+
+```bash
+php artisan reload [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — The commands to skip
+
+Source: https://artisan.page/13.x/reload.md
+
+### `php artisan reverb:install`
+
+Install the Reverb dependencies
+
+```bash
+php artisan reverb:install
+```
+
+Source: https://artisan.page/13.x/reverbinstall.md
+
+### `php artisan reverb:restart`
+
+Restart the Reverb server
+
+```bash
+php artisan reverb:restart
+```
+
+Source: https://artisan.page/13.x/reverbrestart.md
+
+### `php artisan reverb:start`
+
+Start the Reverb server
+
+```bash
+php artisan reverb:start [--host [HOST]] [--port [PORT]] [--path [PATH]] [--hostname [HOSTNAME]] [--debug]
+```
+
+Options:
+- `--debug` — Indicates whether debug messages should be displayed in the terminal
+- `--host` (value optional) — The IP address the server should bind to
+- `--hostname` (value optional) — The hostname the server is accessible from
+- `--path` (value optional) — The path the server should prefix to all routes
+- `--port` (value optional) — The port the server should listen on
+
+Source: https://artisan.page/13.x/reverbstart.md
+
+### `php artisan roster:scan`
+
+Detect packages & approaches in use and output as JSON
+
+```bash
+php artisan roster:scan <directory>
+```
+
+Arguments:
+- `directory` (required)
+
+Source: https://artisan.page/13.x/rosterscan.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/13.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/13.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--json] [--method [METHOD]] [--action [ACTION]] [--name [NAME]] [--domain [DOMAIN]] [--middleware [MIDDLEWARE]] [--path [PATH]] [--except-path [EXCEPT-PATH]] [-r|--reverse] [--sort [SORT]] [--except-vendor] [--only-vendor]
+```
+
+Options:
+- `--action` (value optional) — Filter the routes by action
+- `--domain` (value optional) — Filter the routes by domain
+- `--except-path` (value optional) — Do not display the routes matching the given path pattern
+- `--except-vendor` — Do not display routes defined by vendor packages
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--middleware` (value optional) — Filter the routes by middleware
+- `--name` (value optional) — Filter the routes by name
+- `--only-vendor` — Only display routes defined by vendor packages
+- `--path` (value optional) — Only show routes matching the given path pattern
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware, definition) to sort by; default: `uri`
+
+Source: https://artisan.page/13.x/routelist.md
+
+### `php artisan sail:add`
+
+Add a service to an existing Sail installation
+
+```bash
+php artisan sail:add [<services>]
+```
+
+Arguments:
+- `services` — The services that should be added
+
+Source: https://artisan.page/13.x/sailadd.md
+
+### `php artisan sail:install`
+
+Install Laravel Sail's default Docker Compose file
+
+```bash
+php artisan sail:install [--with [WITH]] [--devcontainer] [--php [PHP]]
+```
+
+Options:
+- `--devcontainer` — Create a .devcontainer configuration directory
+- `--php` (value optional) — The PHP version that should be used; default: `8.5`
+- `--with` (value optional) — The services that should be included in the installation
+
+Source: https://artisan.page/13.x/sailinstall.md
+
+### `php artisan sail:publish`
+
+Publish the Laravel Sail Docker files
+
+```bash
+php artisan sail:publish
+```
+
+Source: https://artisan.page/13.x/sailpublish.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens; default: `24`
+
+Source: https://artisan.page/13.x/sanctumprune-expired.md
+
+### `php artisan schedule:clear-cache`
+
+Delete the cached mutex files created by scheduler
+
+```bash
+php artisan schedule:clear-cache
+```
+
+Source: https://artisan.page/13.x/scheduleclear-cache.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/13.x/schedulefinish.md
+
+### `php artisan schedule:interrupt`
+
+Interrupt the current schedule run
+
+```bash
+php artisan schedule:interrupt
+```
+
+Source: https://artisan.page/13.x/scheduleinterrupt.md
+
+### `php artisan schedule:list`
+
+List all scheduled tasks
+
+```bash
+php artisan schedule:list [--timezone [TIMEZONE]] [--environment [ENVIRONMENT]] [--next] [--json]
+```
+
+Options:
+- `--environment` (value optional) — Display the tasks scheduled to run on this environment
+- `--json` — Output the scheduled tasks as JSON
+- `--next` — Sort the listed tasks by their next due date
+- `--timezone` (value optional) — The timezone that times should be displayed in
+
+Source: https://artisan.page/13.x/schedulelist.md
+
+### `php artisan schedule:pause`
+
+Pause the scheduler
+
+```bash
+php artisan schedule:pause
+```
+
+Source: https://artisan.page/13.x/schedulepause.md
+
+### `php artisan schedule:resume`
+
+Resume the schedule
+
+```bash
+php artisan schedule:resume
+```
+
+Aliases: `schedule:continue`
+
+Source: https://artisan.page/13.x/scheduleresume.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run [--whisper]
+```
+
+Options:
+- `--whisper` — Do not output message indicating that no jobs were ready to run
+
+Source: https://artisan.page/13.x/schedulerun.md
+
+### `php artisan schedule:test`
+
+Run a scheduled command
+
+```bash
+php artisan schedule:test [--name [NAME]]
+```
+
+Options:
+- `--name` (value optional) — The name of the scheduled command to run
+
+Source: https://artisan.page/13.x/scheduletest.md
+
+### `php artisan schedule:work`
+
+Start the schedule worker
+
+```bash
+php artisan schedule:work [--run-output-file [RUN-OUTPUT-FILE]] [--whisper]
+```
+
+Options:
+- `--run-output-file` (value optional) — The file to direct <info>schedule:run</info> output to
+- `--whisper` — Do not output message indicating that no jobs were ready to run
+
+Source: https://artisan.page/13.x/schedulework.md
+
+### `php artisan schema:dump`
+
+Dump the given database schema
+
+```bash
+php artisan schema:dump [--database [DATABASE]] [--path [PATH]] [--prune] [--without-migration-data]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path where the schema dump file should be stored
+- `--prune` — Delete all existing migration files
+- `--without-migration-data` — Dump the schema without the migration data
+
+Source: https://artisan.page/13.x/schemadump.md
+
+### `php artisan scout:delete-all-indexes`
+
+Delete all indexes
+
+```bash
+php artisan scout:delete-all-indexes
+```
+
+Source: https://artisan.page/13.x/scoutdelete-all-indexes.md
+
+### `php artisan scout:delete-index`
+
+Delete an index
+
+```bash
+php artisan scout:delete-index <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Source: https://artisan.page/13.x/scoutdelete-index.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required) — Class name of the model to flush
+
+Source: https://artisan.page/13.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [--fresh] [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+- `--fresh` — Flush the index before importing
+
+Source: https://artisan.page/13.x/scoutimport.md
+
+### `php artisan scout:index`
+
+Create an index
+
+```bash
+php artisan scout:index [-k|--key [KEY]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Options:
+- `--key` (value optional) — The name of the primary key
+
+Source: https://artisan.page/13.x/scoutindex.md
+
+### `php artisan scout:queue-import`
+
+Import the given model into the search index via chunked, queued jobs
+
+```bash
+php artisan scout:queue-import [--min [MIN]] [--max [MAX]] [-c|--chunk [CHUNK]] [--queue [QUEUE]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk queue
+
+Options:
+- `--chunk` (value optional) — The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)
+- `--max` (value optional) — The maximum ID to queue up to
+- `--min` (value optional) — The minimum ID to start queuing from
+- `--queue` (value optional) — The queue that should be used (Defaults to configuration value: `scout.queue.queue`)
+
+Source: https://artisan.page/13.x/scoutqueue-import.md
+
+### `php artisan scout:sync-index-settings`
+
+Sync your configured index settings with your search engine (Meilisearch)
+
+```bash
+php artisan scout:sync-index-settings [--driver [DRIVER]]
+```
+
+Options:
+- `--driver` (value optional) — The name of the search engine driver (Defaults to configuration value: `scout.driver`)
+
+Source: https://artisan.page/13.x/scoutsync-index-settings.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]] [--no-reload]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--no-reload` — Do not reload the development server on .env file changes
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/13.x/serve.md
+
+### `php artisan spark:install`
+
+Install all of the Spark resources
+
+```bash
+php artisan spark:install
+```
+
+Source: https://artisan.page/13.x/sparkinstall.md
+
+### `php artisan storage:link`
+
+Create the symbolic links configured for the application
+
+```bash
+php artisan storage:link [--relative] [--force]
+```
+
+Options:
+- `--force` — Recreate existing symbolic links
+- `--relative` — Create the symbolic link using relative paths
+
+Source: https://artisan.page/13.x/storagelink.md
+
+### `php artisan storage:unlink`
+
+Delete existing symbolic links configured for the application
+
+```bash
+php artisan storage:unlink
+```
+
+Source: https://artisan.page/13.x/storageunlink.md
+
+### `php artisan stub:publish`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan stub:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/13.x/stubpublish.md
+
+### `php artisan telescope:clear`
+
+Delete all Telescope data from storage
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/13.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/13.x/telescopeinstall.md
+
+### `php artisan telescope:pause`
+
+Pause all Telescope watchers
+
+```bash
+php artisan telescope:pause
+```
+
+Source: https://artisan.page/13.x/telescopepause.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]] [--keep-exceptions]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data; default: `24`
+- `--keep-exceptions` — Retain exception data
+
+Source: https://artisan.page/13.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/13.x/telescopepublish.md
+
+### `php artisan telescope:resume`
+
+Unpause all Telescope watchers
+
+```bash
+php artisan telescope:resume
+```
+
+Source: https://artisan.page/13.x/telescoperesume.md
+
+### `php artisan test`
+
+Run the application tests
+
+```bash
+php artisan test [--without-tty] [--compact] [--coverage] [--min [MIN]] [-p|--parallel] [--profile] [--recreate-databases] [--drop-databases] [--without-databases] [--without-cache]
+```
+
+Options:
+- `--compact` — Indicates whether the compact printer should be used
+- `--coverage` — Indicates whether code coverage information should be collected
+- `--drop-databases` — Indicates if the test databases should be dropped
+- `--min` (value optional) — Indicates the minimum threshold enforcement for code coverage
+- `--parallel` — Indicates if the tests should run in parallel
+- `--profile` — Lists top 10 slowest tests
+- `--recreate-databases` — Indicates if the test databases should be re-created
+- `--without-cache` — Indicates if cache configuration should be performed
+- `--without-databases` — Indicates if database configuration should be performed
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/13.x/test.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/13.x/tinker.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/13.x/up.md
+
+### `php artisan vapor:handle`
+
+```bash
+php artisan vapor:handle <payload>
+```
+
+Arguments:
+- `payload` (required)
+
+Source: https://artisan.page/13.x/vaporhandle.md
+
+### `php artisan vapor:health-check`
+
+Check the health of the Vapor application
+
+```bash
+php artisan vapor:health-check
+```
+
+Source: https://artisan.page/13.x/vaporhealth-check.md
+
+### `php artisan vapor:queue-failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan vapor:queue-failed [--limit [LIMIT]] [--page [PAGE]] [--id [ID]] [--queue [QUEUE]] [--query [QUERY]] [--start [START]]
+```
+
+Options:
+- `--id` (value optional) — The job ID filter by
+- `--limit` (value optional) — The number of failed jobs to return
+- `--page` (value optional) — The page of failed jobs to return; default: `1`
+- `--query` (value optional) — The search query to filter by
+- `--queue` (value optional) — The queue to filter by
+- `--start` (value optional) — The start timestamp to filter by
+
+Source: https://artisan.page/13.x/vaporqueue-failed.md
+
+### `php artisan vapor:schedule`
+
+Run the scheduled commands at the beginning of every minute
+
+```bash
+php artisan vapor:schedule
+```
+
+Source: https://artisan.page/13.x/vaporschedule.md
+
+### `php artisan vapor:work`
+
+Process a Vapor job
+
+```bash
+php artisan vapor:work [--delay [DELAY]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--force]
+```
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `0`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/13.x/vaporwork.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--existing] [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/13.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/13.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/13.x/viewclear.md
+
+### `php artisan volt:install`
+
+Install all of the Volt resources
+
+```bash
+php artisan volt:install
+```
+
+Source: https://artisan.page/13.x/voltinstall.md
+
+## Laravel 12.x
+
+258 documented commands.
+
+### `php artisan _complete`
+
+Internal command to provide shell completion suggestions
+
+```bash
+php artisan _complete [-s|--shell SHELL] [-i|--input INPUT] [-c|--current CURRENT] [-a|--api-version API-VERSION] [-S|--symfony SYMFONY]
+```
+
+Options:
+- `--api-version` (value required) — The API version of the completion script
+- `--current` (value required) — The index of the "input" array that the cursor is in (e.g. COMP_CWORD)
+- `--input` (value required) — An array of input tokens (e.g. COMP_WORDS or argv)
+- `--shell` (value required) — The shell type ("bash", "fish", "zsh")
+- `--symfony` (value required) — deprecated
+
+Source: https://artisan.page/12.x/_complete.md
+
+### `php artisan about`
+
+Display basic information about your application
+
+```bash
+php artisan about [--only [ONLY]] [--json]
+```
+
+Options:
+- `--json` — Output the information as JSON
+- `--only` (value optional) — The section to display
+
+Source: https://artisan.page/12.x/about.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/12.x/authclear-resets.md
+
+### `php artisan boost:add-skill`
+
+Add skills from a remote GitHub repository
+
+```bash
+php artisan boost:add-skill [--list] [--all] [--skill [SKILL]] [--force] [--skip-audit] [--] [<repo>]
+```
+
+Arguments:
+- `repo` — GitHub repository (owner/repo or full URL)
+
+Options:
+- `--all` — Install all skills
+- `--force` — Overwrite existing skills
+- `--list` — List available skills
+- `--skill` (value optional) — Specific skills to install
+- `--skip-audit` — Skip security audit
+
+Source: https://artisan.page/12.x/boostadd-skill.md
+
+### `php artisan boost:execute-tool`
+
+Execute a Boost MCP tool in isolation (internal command)
+
+```bash
+php artisan boost:execute-tool <tool> <arguments>
+```
+
+Arguments:
+- `tool` (required)
+- `arguments` (required)
+
+Source: https://artisan.page/12.x/boostexecute-tool.md
+
+### `php artisan boost:install`
+
+```bash
+php artisan boost:install [--guidelines] [--skills] [--mcp]
+```
+
+Options:
+- `--guidelines` — Install AI guidelines
+- `--mcp` — Install MCP server configuration
+- `--skills` — Install agent skills
+
+Source: https://artisan.page/12.x/boostinstall.md
+
+### `php artisan boost:list-skills`
+
+List all available skills in the current project
+
+```bash
+php artisan boost:list-skills
+```
+
+Source: https://artisan.page/12.x/boostlist-skills.md
+
+### `php artisan boost:mcp`
+
+Starts Laravel Boost (usually from mcp.json)
+
+```bash
+php artisan boost:mcp
+```
+
+Source: https://artisan.page/12.x/boostmcp.md
+
+### `php artisan boost:update`
+
+Update the Laravel Boost guidelines & skills to the latest guidance
+
+```bash
+php artisan boost:update [--discover] [--ignore-skills]
+```
+
+Options:
+- `--discover` — Discover and prompt for newly available guidelines and skills
+- `--ignore-skills` — Skip updating the skills directory
+
+Source: https://artisan.page/12.x/boostupdate.md
+
+### `php artisan breeze:install`
+
+Install the Breeze controllers and resources
+
+```bash
+php artisan breeze:install [--dark] [--pest] [--ssr] [--typescript] [--eslint] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (blade,livewire,livewire-functional,react,vue,api)
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--eslint` — Indicates if ESLint with Prettier should be installed
+- `--pest` — Indicate that Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--typescript` — Indicates if TypeScript is preferred for the Inertia stack
+
+Source: https://artisan.page/12.x/breezeinstall.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/12.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/12.x/cacheforget.md
+
+### `php artisan cache:prune-stale-tags`
+
+Prune stale cache tags from the cache (Redis only)
+
+```bash
+php artisan cache:prune-stale-tags [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to prune tags from
+
+Source: https://artisan.page/12.x/cacheprune-stale-tags.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/12.x/cashierwebhook.md
+
+### `php artisan channel:list`
+
+List all registered private broadcast channels
+
+```bash
+php artisan channel:list
+```
+
+Source: https://artisan.page/12.x/channellist.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/12.x/clear-compiled.md
+
+### `php artisan completion`
+
+Dump the shell completion script
+
+```bash
+php artisan completion [--debug] [--] [<shell>]
+```
+
+Arguments:
+- `shell` — The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+Options:
+- `--debug` — Tail the completion debug log
+
+Source: https://artisan.page/12.x/completion.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/12.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/12.x/configclear.md
+
+### `php artisan config:publish`
+
+Publish configuration files to your application
+
+```bash
+php artisan config:publish [--all] [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the configuration file to publish
+
+Options:
+- `--all` — Publish all configuration files
+- `--force` — Overwrite any existing configuration files
+
+Source: https://artisan.page/12.x/configpublish.md
+
+### `php artisan config:show`
+
+Display all of the values for a given configuration file or key
+
+```bash
+php artisan config:show <config>
+```
+
+Arguments:
+- `config` (required) — The configuration file or key to show
+
+Source: https://artisan.page/12.x/configshow.md
+
+### `php artisan db`
+
+Start a new database CLI session
+
+```bash
+php artisan db [--read] [--write] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The database connection that should be used
+
+Options:
+- `--read` — Connect to the read connection
+- `--write` — Connect to the write connection
+
+Source: https://artisan.page/12.x/db.md
+
+### `php artisan db:monitor`
+
+Monitor the number of connections on the specified database
+
+```bash
+php artisan db:monitor [--databases [DATABASES]] [--max [MAX]]
+```
+
+Options:
+- `--databases` (value optional) — The database connections to monitor
+- `--max` (value optional) — The maximum number of connections that can be open before an event is dispatched
+
+Source: https://artisan.page/12.x/dbmonitor.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force] [--] [<class>]
+```
+
+Arguments:
+- `class` — The class name of the root seeder
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `Database\Seeders\DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/12.x/dbseed.md
+
+### `php artisan db:show`
+
+Display information about the given database
+
+```bash
+php artisan db:show [--database [DATABASE]] [--json] [--counts] [--views] [--types]
+```
+
+Options:
+- `--counts` — Show the table row count <bg=red;options=bold> Note: This can be slow on large databases </>
+- `--database` (value optional) — The database connection
+- `--json` — Output the database information as JSON
+- `--types` — Show the user defined types
+- `--views` — Show the database views <bg=red;options=bold> Note: This can be slow on large databases </>
+
+Source: https://artisan.page/12.x/dbshow.md
+
+### `php artisan db:table`
+
+Display information about the given database table
+
+```bash
+php artisan db:table [--database [DATABASE]] [--json] [--] [<table>]
+```
+
+Arguments:
+- `table` — The name of the table
+
+Options:
+- `--database` (value optional) — The database connection
+- `--json` — Output the table information as JSON
+
+Source: https://artisan.page/12.x/dbtable.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/12.x/dbwipe.md
+
+### `php artisan docs`
+
+Access the Laravel documentation
+
+```bash
+php artisan docs [<page> [<section>]]
+```
+
+Arguments:
+- `page` — The documentation page to open
+- `section` — The section of the page to open
+
+Source: https://artisan.page/12.x/docs.md
+
+### `php artisan down`
+
+Put the application into maintenance / demo mode
+
+```bash
+php artisan down [--redirect [REDIRECT]] [--render [RENDER]] [--retry [RETRY]] [--refresh [REFRESH]] [--secret [SECRET]] [--with-secret] [--status [STATUS]]
+```
+
+Options:
+- `--redirect` (value optional) — The path that users should be redirected to
+- `--refresh` (value optional) — The number of seconds after which the browser may refresh
+- `--render` (value optional) — The view that should be prerendered for display during maintenance mode
+- `--retry` (value optional) — The number of seconds or the datetime after which the request may be retried
+- `--secret` (value optional) — The secret phrase that may be used to bypass maintenance mode
+- `--status` (value optional) — The status code that should be used when returning the maintenance mode response; default: `503`
+- `--with-secret` — Generate a random secret phrase that may be used to bypass maintenance mode
+
+Source: https://artisan.page/12.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/12.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/12.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/12.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/12.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/12.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/12.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/12.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/12.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/12.x/env.md
+
+### `php artisan env:decrypt`
+
+Decrypt an environment file
+
+```bash
+php artisan env:decrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--force] [--path [PATH]] [--filename [FILENAME]]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be decrypted
+- `--filename` (value optional) — Filename of the decrypted file
+- `--force` — Overwrite the existing environment file
+- `--key` (value optional) — The encryption key
+- `--path` (value optional) — Path to write the decrypted file
+
+Source: https://artisan.page/12.x/envdecrypt.md
+
+### `php artisan env:encrypt`
+
+Encrypt an environment file
+
+```bash
+php artisan env:encrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--readable] [--prune] [--force]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be encrypted
+- `--force` — Overwrite the existing encrypted environment file
+- `--key` (value optional) — The encryption key
+- `--prune` — Delete the original environment file
+- `--readable` — Encrypt each variable individually with readable, plain-text variable names
+
+Source: https://artisan.page/12.x/envencrypt.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/12.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/12.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/12.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]] [--json]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+- `--json` — Output the events and listeners as JSON
+
+Source: https://artisan.page/12.x/eventlist.md
+
+### `php artisan fortify:install`
+
+Install all of the Fortify resources
+
+```bash
+php artisan fortify:install
+```
+
+Source: https://artisan.page/12.x/fortifyinstall.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/12.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/12.x/horizon.md
+
+### `php artisan horizon:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan horizon:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/12.x/horizonclear.md
+
+### `php artisan horizon:clear-metrics`
+
+Delete metrics for all jobs and queues
+
+```bash
+php artisan horizon:clear-metrics
+```
+
+Source: https://artisan.page/12.x/horizonclear-metrics.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/12.x/horizoncontinue.md
+
+### `php artisan horizon:continue-supervisor`
+
+Instruct the supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to resume
+
+Source: https://artisan.page/12.x/horizoncontinue-supervisor.md
+
+### `php artisan horizon:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan horizon:forget [--all] [--] [<id>]
+```
+
+Arguments:
+- `id` — The ID of the failed job
+
+Options:
+- `--all` — Delete all failed jobs
+
+Source: https://artisan.page/12.x/horizonforget.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/12.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/12.x/horizonlist.md
+
+### `php artisan horizon:listen`
+
+Run Horizon and automatically restart workers on file changes
+
+```bash
+php artisan horizon:listen [--environment [ENVIRONMENT]] [--poll]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+- `--poll` — Use polling for file watching
+
+Source: https://artisan.page/12.x/horizonlisten.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/12.x/horizonpause.md
+
+### `php artisan horizon:pause-supervisor`
+
+Pause a supervisor
+
+```bash
+php artisan horizon:pause-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to pause
+
+Source: https://artisan.page/12.x/horizonpause-supervisor.md
+
+### `php artisan horizon:publish`
+
+Publish all of the Horizon resources
+
+```bash
+php artisan horizon:publish
+```
+
+Source: https://artisan.page/12.x/horizonpublish.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge [--signal [SIGNAL]]
+```
+
+Options:
+- `--signal` (value optional) — The signal to send to the rogue processes; default: `SIGTERM`
+
+Source: https://artisan.page/12.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/12.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/12.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--auto-scaling-strategy [AUTO-SCALING-STRATEGY]] [--balance-cooldown [BALANCE-COOLDOWN]] [--balance-max-shift [BALANCE-MAX-SHIFT]] [--workers-name [WORKERS-NAME]] [--parent-id [PARENT-ID]] [--rest [REST]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--auto-scaling-strategy` (value optional) — If supervisor should scale by jobs or time to complete; default: `time`
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--balance-cooldown` (value optional) — The number of seconds to wait in between auto-scaling attempts; default: `3`
+- `--balance-max-shift` (value optional) — The maximum number of processes to increase or decrease per one scaling; default: `1`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping a child process; default: `0`
+- `--max-processes` (value optional) — The maximum number of total workers to start; default: `1`
+- `--max-time` (value optional) — The maximum number of seconds a child process should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue; default: `1`
+- `--nice` (value optional) — The process priority; default: `0`
+- `--parent-id` (value optional) — The parent process ID; default: `0`
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+- `--workers-name` (value optional) — The name that should be assigned to the workers; default: `default`
+
+Source: https://artisan.page/12.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisor-status`
+
+Show the status for a given supervisor
+
+```bash
+php artisan horizon:supervisor-status <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor
+
+Source: https://artisan.page/12.x/horizonsupervisor-status.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/12.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/12.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/12.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--stop-when-empty-for [STOP-WHEN-EMPTY-FOR]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--json] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--json` — Output the queue worker information as JSON
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--stop-when-empty-for` (value optional) — Stop when no jobs have been processed for the given number of seconds; default: `0`
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/12.x/horizonwork.md
+
+### `php artisan inertia:check-ssr`
+
+Check the Inertia SSR server health status
+
+```bash
+php artisan inertia:check-ssr
+```
+
+Source: https://artisan.page/12.x/inertiacheck-ssr.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/12.x/inertiamiddleware.md
+
+### `php artisan inertia:start-ssr`
+
+Start the Inertia SSR server
+
+```bash
+php artisan inertia:start-ssr [--runtime [RUNTIME]]
+```
+
+Options:
+- `--runtime` (value optional) — The runtime to use (e.g. `node`, `bun`, or an absolute path)
+
+Source: https://artisan.page/12.x/inertiastart-ssr.md
+
+### `php artisan inertia:stop-ssr`
+
+Stop the Inertia SSR server
+
+```bash
+php artisan inertia:stop-ssr
+```
+
+Source: https://artisan.page/12.x/inertiastop-ssr.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/12.x/inspire.md
+
+### `php artisan install:api`
+
+Create an API routes file and install Laravel Sanctum or Laravel Passport
+
+```bash
+php artisan install:api [--composer [COMPOSER]] [--force] [--passport] [--without-migration-prompt]
+```
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--force` — Overwrite any existing API routes file
+- `--passport` — Install Laravel Passport instead of Laravel Sanctum
+- `--without-migration-prompt` — Do not prompt to run pending migrations
+
+Source: https://artisan.page/12.x/installapi.md
+
+### `php artisan install:broadcasting`
+
+Create a broadcasting channel routes file
+
+```bash
+php artisan install:broadcasting [--composer [COMPOSER]] [--force] [--without-reverb] [--reverb] [--pusher] [--ably] [--without-node]
+```
+
+Options:
+- `--ably` — Install Ably as the default broadcaster
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--force` — Overwrite any existing broadcasting routes file
+- `--pusher` — Install Pusher as the default broadcaster
+- `--reverb` — Install Laravel Reverb as the default broadcaster
+- `--without-node` — Do not prompt to install Node dependencies
+- `--without-reverb` — Do not prompt to install Laravel Reverb
+
+Source: https://artisan.page/12.x/installbroadcasting.md
+
+### `php artisan invoke-serialized-closure`
+
+Invoke the given serialized closure
+
+```bash
+php artisan invoke-serialized-closure [<code>]
+```
+
+Arguments:
+- `code` — The serialized closure
+
+Source: https://artisan.page/12.x/invoke-serialized-closure.md
+
+### `php artisan jetstream:install`
+
+Install the Jetstream components and resources
+
+```bash
+php artisan jetstream:install [--dark] [--teams] [--api] [--verification] [--pest] [--ssr] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (inertia,livewire)
+
+Options:
+- `--api` — Indicates if API support should be installed
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--pest` — Indicates if Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--teams` — Indicates if team support should be installed
+- `--verification` — Indicates if email verification support should be installed
+
+Source: https://artisan.page/12.x/jetstreaminstall.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/12.x/keygenerate.md
+
+### `php artisan lang:publish`
+
+Publish all language files that are available for customization
+
+```bash
+php artisan lang:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/12.x/langpublish.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--short] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+- `--short` — To skip describing commands' arguments
+
+Source: https://artisan.page/12.x/list.md
+
+### `php artisan livewire:attribute`
+
+Create a new Livewire attribute class
+
+```bash
+php artisan livewire:attribute [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/12.x/livewireattribute.md
+
+### `php artisan livewire:config`
+
+Publish Livewire config file
+
+```bash
+php artisan livewire:config
+```
+
+Source: https://artisan.page/12.x/livewireconfig.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/12.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:convert`
+
+Convert a Livewire component between single-file and multi-file formats
+
+```bash
+php artisan livewire:convert [--sfc] [--mfc] [--test] [--emoji EMOJI] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--mfc` — Convert to multi-file component
+- `--sfc` — Convert to single-file component
+- `--test` — Create a test file when converting to multi-file (if one does not exist)
+
+Source: https://artisan.page/12.x/livewireconvert.md
+
+### `php artisan livewire:form`
+
+Create a new Livewire form class
+
+```bash
+php artisan livewire:form [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/12.x/livewireform.md
+
+### `php artisan livewire:layout`
+
+Create a new app layout file
+
+```bash
+php artisan livewire:layout [--force] [--stub [STUB]]
+```
+
+Options:
+- `--force`
+- `--stub` (value optional) — If you have several stubs, stored in subfolders
+
+Source: https://artisan.page/12.x/livewirelayout.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/12.x/livewiremake.md
+
+### `php artisan livewire:publish`
+
+Publish Livewire configuration
+
+```bash
+php artisan livewire:publish [--assets] [--config] [--pagination]
+```
+
+Options:
+- `--assets` — Indicates if Livewire's front-end assets should be published
+- `--config` — Indicates if Livewire's config file should be published
+- `--pagination` — Indicates if Livewire's pagination views should be published
+
+Source: https://artisan.page/12.x/livewirepublish.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/12.x/livewirestubs.md
+
+### `php artisan make:cache-table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan make:cache-table
+```
+
+Aliases: `cache:table`
+
+Source: https://artisan.page/12.x/makecache-table.md
+
+### `php artisan make:cast`
+
+Create a new custom Eloquent cast class
+
+```bash
+php artisan make:cast [-f|--force] [--inbound] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the cast
+
+Options:
+- `--force` — Create the class even if the cast already exists
+- `--inbound` — Generate an inbound cast class
+
+Source: https://artisan.page/12.x/makecast.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the channel
+
+Options:
+- `--force` — Create the class even if the channel already exists
+
+Source: https://artisan.page/12.x/makechannel.md
+
+### `php artisan make:class`
+
+Create a new class
+
+```bash
+php artisan make:class [-i|--invokable] [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the class already exists
+- `--invokable` — Generate a single method, invokable class
+
+Source: https://artisan.page/12.x/makeclass.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [-f|--force] [--command [COMMAND]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that will be used to invoke the class
+- `--force` — Create the class even if the console command already exists
+- `--pest` — Generate an accompanying Pest test for the Console command
+- `--phpunit` — Generate an accompanying PHPUnit test for the Console command
+- `--test` — Generate an accompanying Test test for the Console command
+
+Source: https://artisan.page/12.x/makecommand.md
+
+### `php artisan make:component`
+
+Create a new view component class
+
+```bash
+php artisan make:component [--inline] [--view] [--path PATH] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--force` — Create the class even if the component already exists
+- `--inline` — Create a component that renders an inline view
+- `--path` (value required) — The location where the component view should be created
+- `--pest` — Generate an accompanying Pest test for the Component
+- `--phpunit` — Generate an accompanying PHPUnit test for the Component
+- `--test` — Generate an accompanying Test test for the Component
+- `--view` — Create an anonymous component with only a view
+
+Source: https://artisan.page/12.x/makecomponent.md
+
+### `php artisan make:config`
+
+Create a new configuration file
+
+```bash
+php artisan make:config [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the config
+
+Options:
+- `--force` — Create the configuration file even if it already exists
+
+Aliases: `config:make`
+
+Source: https://artisan.page/12.x/makeconfig.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--type TYPE] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [-R|--requests] [-s|--singleton] [--creatable] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the controller
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller
+- `--creatable` — Indicate that a singleton resource should be creatable
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class
+- `--model` (value optional) — Generate a resource controller for the given model
+- `--parent` (value optional) — Generate a nested resource controller class
+- `--pest` — Generate an accompanying Pest test for the Controller
+- `--phpunit` — Generate an accompanying PHPUnit test for the Controller
+- `--requests` — Generate FormRequest classes for store and update
+- `--resource` — Generate a resource controller class
+- `--singleton` — Generate a singleton resource controller class
+- `--test` — Generate an accompanying Test test for the Controller
+- `--type` (value required) — Manually specify the controller stub file to use
+
+Source: https://artisan.page/12.x/makecontroller.md
+
+### `php artisan make:enum`
+
+Create a new enum
+
+```bash
+php artisan make:enum [-s|--string] [-i|--int] [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the enum
+
+Options:
+- `--force` — Create the enum even if the enum already exists
+- `--int` — Generate an integer backed enum.
+- `--string` — Generate a string backed enum.
+
+Source: https://artisan.page/12.x/makeenum.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the event
+
+Options:
+- `--force` — Create the class even if the event already exists
+
+Source: https://artisan.page/12.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [-f|--force] [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the exception
+
+Options:
+- `--force` — Create the class even if the exception already exists
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/12.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the factory
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/12.x/makefactory.md
+
+### `php artisan make:interface`
+
+Create a new interface
+
+```bash
+php artisan make:interface [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the interface
+
+Options:
+- `--force` — Create the interface even if the interface already exists
+
+Source: https://artisan.page/12.x/makeinterface.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [-f|--force] [--sync] [--batched] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the job
+
+Options:
+- `--batched` — Indicates that the job should be batchable
+- `--force` — Create the class even if the job already exists
+- `--pest` — Generate an accompanying Pest test for the Job
+- `--phpunit` — Generate an accompanying PHPUnit test for the Job
+- `--sync` — Indicates that the job should be synchronous
+- `--test` — Generate an accompanying Test test for the Job
+
+Source: https://artisan.page/12.x/makejob.md
+
+### `php artisan make:job-middleware`
+
+Create a new job middleware class
+
+```bash
+php artisan make:job-middleware [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--force` — Create the class even if the job middleware already exists
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--phpunit` — Generate an accompanying PHPUnit test for the Middleware
+- `--test` — Generate an accompanying Test test for the Middleware
+
+Source: https://artisan.page/12.x/makejob-middleware.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [-f|--force] [--queued] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the listener
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--force` — Create the class even if the listener already exists
+- `--pest` — Generate an accompanying Pest test for the Listener
+- `--phpunit` — Generate an accompanying PHPUnit test for the Listener
+- `--queued` — Indicates the event listener should be queued
+- `--test` — Generate an accompanying Test test for the Listener
+
+Source: https://artisan.page/12.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/12.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--view [VIEW]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the mailable
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+- `--pest` — Generate an accompanying Pest test for the Mailable
+- `--phpunit` — Generate an accompanying PHPUnit test for the Mailable
+- `--test` — Generate an accompanying Test test for the Mailable
+- `--view` (value optional) — Create a new Blade template for the mailable
+
+Source: https://artisan.page/12.x/makemail.md
+
+### `php artisan make:mcp-app-resource`
+
+Create a new MCP app resource class and linked view
+
+```bash
+php artisan make:mcp-app-resource [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the appresource
+
+Options:
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/12.x/makemcp-app-resource.md
+
+### `php artisan make:mcp-prompt`
+
+Create a new MCP prompt class
+
+```bash
+php artisan make:mcp-prompt [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the prompt
+
+Options:
+- `--force` — Create the class even if the prompt already exists
+
+Source: https://artisan.page/12.x/makemcp-prompt.md
+
+### `php artisan make:mcp-resource`
+
+Create a new MCP resource class
+
+```bash
+php artisan make:mcp-resource [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/12.x/makemcp-resource.md
+
+### `php artisan make:mcp-server`
+
+Create a new MCP server class
+
+```bash
+php artisan make:mcp-server [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the server
+
+Options:
+- `--force` — Create the class even if the server already exists
+
+Source: https://artisan.page/12.x/makemcp-server.md
+
+### `php artisan make:mcp-tool`
+
+Create a new MCP tool class
+
+```bash
+php artisan make:mcp-tool [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the tool
+
+Options:
+- `--force` — Create the class even if the tool already exists
+
+Source: https://artisan.page/12.x/makemcp-tool.md
+
+### `php artisan make:middleware`
+
+Create a new HTTP middleware class
+
+```bash
+php artisan make:middleware [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--phpunit` — Generate an accompanying PHPUnit test for the Middleware
+- `--test` — Generate an accompanying Test test for the Middleware
+
+Source: https://artisan.page/12.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration (Deprecated)
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/12.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [--morph-pivot] [--policy] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [-R|--requests] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the model
+
+Options:
+- `--all` — Generate a migration, seeder, factory, policy, resource controller, and form request classes for the model
+- `--api` — Indicates if the generated controller should be an API resource controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--morph-pivot` — Indicates if the generated model should be a custom polymorphic intermediate table model
+- `--pest` — Generate an accompanying Pest test for the Model
+- `--phpunit` — Generate an accompanying PHPUnit test for the Model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--policy` — Create a new policy for the model
+- `--requests` — Create new form request classes and use them in the resource controller
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder for the model
+- `--test` — Generate an accompanying Test test for the Model
+
+Source: https://artisan.page/12.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the notification
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+- `--pest` — Generate an accompanying Pest test for the Notification
+- `--phpunit` — Generate an accompanying PHPUnit test for the Notification
+- `--test` — Generate an accompanying Test test for the Notification
+
+Source: https://artisan.page/12.x/makenotification.md
+
+### `php artisan make:notifications-table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan make:notifications-table
+```
+
+Aliases: `notifications:table`
+
+Source: https://artisan.page/12.x/makenotifications-table.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-f|--force] [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the observer
+
+Options:
+- `--force` — Create the class even if the observer already exists
+- `--model` (value optional) — The model that the observer applies to
+
+Source: https://artisan.page/12.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-f|--force] [-m|--model [MODEL]] [-g|--guard [GUARD]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--guard` (value optional) — The guard that the policy relies on
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/12.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the provider
+
+Options:
+- `--force` — Create the class even if the provider already exists
+
+Source: https://artisan.page/12.x/makeprovider.md
+
+### `php artisan make:queue-batches-table`
+
+Create a migration for the batches database table
+
+```bash
+php artisan make:queue-batches-table
+```
+
+Aliases: `queue:batches-table`
+
+Source: https://artisan.page/12.x/makequeue-batches-table.md
+
+### `php artisan make:queue-failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan make:queue-failed-table
+```
+
+Aliases: `queue:failed-table`
+
+Source: https://artisan.page/12.x/makequeue-failed-table.md
+
+### `php artisan make:queue-table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan make:queue-table
+```
+
+Aliases: `queue:table`
+
+Source: https://artisan.page/12.x/makequeue-table.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the request
+
+Options:
+- `--force` — Create the class even if the request already exists
+
+Source: https://artisan.page/12.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-f|--force] [-j|--json-api] [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--collection` — Create a resource collection
+- `--force` — Create the class even if the resource already exists
+- `--json-api` — Create a JSON:API resource
+
+Source: https://artisan.page/12.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule [-f|--force] [-i|--implicit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the rule
+
+Options:
+- `--force` — Create the class even if the rule already exists
+- `--implicit` — Generate an implicit rule
+
+Source: https://artisan.page/12.x/makerule.md
+
+### `php artisan make:scope`
+
+Create a new scope class
+
+```bash
+php artisan make:scope [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the scope
+
+Options:
+- `--force` — Create the class even if the scope already exists
+
+Source: https://artisan.page/12.x/makescope.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the seeder
+
+Source: https://artisan.page/12.x/makeseeder.md
+
+### `php artisan make:session-table`
+
+Create a migration for the session database table
+
+```bash
+php artisan make:session-table
+```
+
+Aliases: `session:table`
+
+Source: https://artisan.page/12.x/makesession-table.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [-f|--force] [-u|--unit] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the test
+
+Options:
+- `--force` — Create the test even if the test already exists
+- `--pest` — Create a Pest test
+- `--phpunit` — Create a PHPUnit test
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/12.x/maketest.md
+
+### `php artisan make:trait`
+
+Create a new trait
+
+```bash
+php artisan make:trait [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the trait
+
+Options:
+- `--force` — Create the trait even if the trait already exists
+
+Source: https://artisan.page/12.x/maketrait.md
+
+### `php artisan make:view`
+
+Create a new view
+
+```bash
+php artisan make:view [--extension [EXTENSION]] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the view
+
+Options:
+- `--extension` (value optional) — The extension of the generated view; default: `blade.php`
+- `--force` — Create the view even if the view already exists
+- `--pest` — Generate an accompanying Pest test for the View
+- `--phpunit` — Generate an accompanying PHPUnit test for the View
+- `--test` — Generate an accompanying Test test for the View
+
+Source: https://artisan.page/12.x/makeview.md
+
+### `php artisan make:volt`
+
+Create a new Volt component
+
+```bash
+php artisan make:volt [--class] [--functional] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the volt component
+
+Options:
+- `--class` — Create a class based component
+- `--force` — Create the Volt component even if the component already exists
+- `--functional` — Create a functional component
+- `--pest` — Generate an accompanying Pest test for the Volt component
+- `--phpunit` — Generate an accompanying PHPUnit test for the Volt component
+- `--test` — Generate an accompanying Test test for the Volt component
+
+Source: https://artisan.page/12.x/makevolt.md
+
+### `php artisan mcp:inspector`
+
+Open the MCP Inspector tool to debug and test MCP Servers
+
+```bash
+php artisan mcp:inspector [--host [HOST]] [--port [PORT]] [--] <handle>
+```
+
+Arguments:
+- `handle` (required) — The handle or route of the MCP server to inspect.
+
+Options:
+- `--host` (value optional) — The host the inspector should bind to
+- `--port` (value optional) — The port the inspector should bind to
+
+Source: https://artisan.page/12.x/mcpinspector.md
+
+### `php artisan mcp:start`
+
+Start the MCP Server for a given handle
+
+```bash
+php artisan mcp:start <handle>
+```
+
+Arguments:
+- `handle` (required) — The handle of the MCP server to start.
+
+Source: https://artisan.page/12.x/mcpstart.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--pretend] [--seed] [--seeder [SEEDER]] [--step] [--graceful] [--isolated [ISOLATED]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--graceful` — Return a successful exit code even if an error occurs
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/12.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/12.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/12.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/12.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/12.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]] [--batch BATCH]
+```
+
+Options:
+- `--batch` (value required) — The batch of migrations (identified by their batch number) to be reverted
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/12.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--pending [PENDING]] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--pending` (value optional) — Only list pending migrations
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/12.x/migratestatus.md
+
+### `php artisan model:prune`
+
+Prune models that are no longer needed
+
+```bash
+php artisan model:prune [--model [MODEL]] [--except [EXCEPT]] [--path [PATH]] [--chunk [CHUNK]] [--pretend]
+```
+
+Options:
+- `--chunk` (value optional) — The number of models to retrieve per chunk of models to be deleted; default: `1000`
+- `--except` (value optional) — Class names of the models to be excluded from pruning
+- `--model` (value optional) — Class names of the models to be pruned
+- `--path` (value optional) — Absolute path(s) to directories where models are located
+- `--pretend` — Display the number of prunable records found instead of deleting them
+
+Source: https://artisan.page/12.x/modelprune.md
+
+### `php artisan model:show`
+
+Show information about an Eloquent model
+
+```bash
+php artisan model:show [--database [DATABASE]] [--json] [--] <model>
+```
+
+Arguments:
+- `model` (required) — The model to show
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--json` — Output the model as JSON
+
+Source: https://artisan.page/12.x/modelshow.md
+
+### `php artisan nightwatch:agent`
+
+Run the Nightwatch agent.
+
+```bash
+php artisan nightwatch:agent [--listen-on [LISTEN-ON]] [--auth-connection-timeout [AUTH-CONNECTION-TIMEOUT]] [--auth-timeout [AUTH-TIMEOUT]] [--ingest-connection-timeout [INGEST-CONNECTION-TIMEOUT]] [--ingest-timeout [INGEST-TIMEOUT]] [--server [SERVER]] [--silent]
+```
+
+Options:
+- `--auth-connection-timeout` (value optional)
+- `--auth-timeout` (value optional)
+- `--ingest-connection-timeout` (value optional)
+- `--ingest-timeout` (value optional)
+- `--listen-on` (value optional)
+- `--server` (value optional)
+- `--silent` — Do not output any message
+
+Source: https://artisan.page/12.x/nightwatchagent.md
+
+### `php artisan nightwatch:deploy`
+
+Send deployment metadata to Nightwatch.
+
+```bash
+php artisan nightwatch:deploy [--ref [REF]] [--name [NAME]] [--url [URL]] [--timestamp [TIMESTAMP]] [--] [<deploy>]
+```
+
+Arguments:
+- `deploy` — A unique value for the deploy <comment>[default: `NIGHTWATCH_DEPLOY`]</comment>
+
+Options:
+- `--name` (value optional) — The human-readable name of the deploy
+- `--ref` (value optional) — The git ref (tag or hash) of the deploy
+- `--timestamp` (value optional) — The timestamp of the deploy <comment>[default: `now()`]</comment>
+- `--url` (value optional) — A URL with information related to the deploy
+
+Source: https://artisan.page/12.x/nightwatchdeploy.md
+
+### `php artisan nightwatch:status`
+
+Get the current status of the Nightwatch agent.
+
+```bash
+php artisan nightwatch:status
+```
+
+Source: https://artisan.page/12.x/nightwatchstatus.md
+
+### `php artisan nova:action`
+
+Create a new action class
+
+```bash
+php artisan nova:action [--destructive] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the action
+
+Options:
+- `--destructive` — Indicate that the action deletes / destroys resources
+- `--queued` — Indicates the action should be queued
+
+Source: https://artisan.page/12.x/novaaction.md
+
+### `php artisan nova:asset`
+
+Create a new asset
+
+```bash
+php artisan nova:asset <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/12.x/novaasset.md
+
+### `php artisan nova:base-resource`
+
+Create a new base resource class
+
+```bash
+php artisan nova:base-resource <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Source: https://artisan.page/12.x/novabase-resource.md
+
+### `php artisan nova:card`
+
+Create a new card
+
+```bash
+php artisan nova:card <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/12.x/novacard.md
+
+### `php artisan nova:check-license`
+
+Verify your Nova license key
+
+```bash
+php artisan nova:check-license
+```
+
+Source: https://artisan.page/12.x/novacheck-license.md
+
+### `php artisan nova:custom-filter`
+
+Create a new custom filter
+
+```bash
+php artisan nova:custom-filter <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/12.x/novacustom-filter.md
+
+### `php artisan nova:dashboard`
+
+Create a new dashboard.
+
+```bash
+php artisan nova:dashboard <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/12.x/novadashboard.md
+
+### `php artisan nova:field`
+
+Create a new field
+
+```bash
+php artisan nova:field <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/12.x/novafield.md
+
+### `php artisan nova:filter`
+
+Create a new filter class
+
+```bash
+php artisan nova:filter [--boolean] [--date] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the filter
+
+Options:
+- `--boolean` — Indicates if the generated filter should be a boolean filter
+- `--date` — Indicates if the generated filter should be a date filter
+
+Source: https://artisan.page/12.x/novafilter.md
+
+### `php artisan nova:install`
+
+Install all of the Nova resources
+
+```bash
+php artisan nova:install
+```
+
+Source: https://artisan.page/12.x/novainstall.md
+
+### `php artisan nova:lens`
+
+Create a new lens class
+
+```bash
+php artisan nova:lens <name>
+```
+
+Arguments:
+- `name` (required) — The name of the lens
+
+Source: https://artisan.page/12.x/novalens.md
+
+### `php artisan nova:partition`
+
+Create a new metric (partition) class
+
+```bash
+php artisan nova:partition <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/12.x/novapartition.md
+
+### `php artisan nova:policy`
+
+Create a new policy class
+
+```bash
+php artisan nova:policy [-f|--force] [-m|--resource [RESOURCE]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--resource` (value optional) — The resource that the policy applies to
+
+Source: https://artisan.page/12.x/novapolicy.md
+
+### `php artisan nova:progress`
+
+Create a new metric (progress) class
+
+```bash
+php artisan nova:progress <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/12.x/novaprogress.md
+
+### `php artisan nova:publish`
+
+Publish all of the Nova resources
+
+```bash
+php artisan nova:publish [-f|--force] [--fortify|--no-fortify]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+- `--fortify` — Publish Laravel Fortify features
+
+Source: https://artisan.page/12.x/novapublish.md
+
+### `php artisan nova:repeatable`
+
+Create a new repeatable class
+
+```bash
+php artisan nova:repeatable [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the repeatable
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/12.x/novarepeatable.md
+
+### `php artisan nova:resource`
+
+Create a new resource class
+
+```bash
+php artisan nova:resource [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/12.x/novaresource.md
+
+### `php artisan nova:resource-tool`
+
+Create a new resource tool
+
+```bash
+php artisan nova:resource-tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/12.x/novaresource-tool.md
+
+### `php artisan nova:stubs`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan nova:stubs [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/12.x/novastubs.md
+
+### `php artisan nova:table`
+
+Create a new metric (table) class
+
+```bash
+php artisan nova:table <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/12.x/novatable.md
+
+### `php artisan nova:tool`
+
+Create a new tool
+
+```bash
+php artisan nova:tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/12.x/novatool.md
+
+### `php artisan nova:translate`
+
+Create translation files for Nova
+
+```bash
+php artisan nova:translate [--force] [--] <language>
+```
+
+Arguments:
+- `language` (required)
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/12.x/novatranslate.md
+
+### `php artisan nova:trend`
+
+Create a new metric (trend) class
+
+```bash
+php artisan nova:trend <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/12.x/novatrend.md
+
+### `php artisan nova:user`
+
+Create a new user
+
+```bash
+php artisan nova:user
+```
+
+Source: https://artisan.page/12.x/novauser.md
+
+### `php artisan nova:value`
+
+Create a new metric (single value) class
+
+```bash
+php artisan nova:value <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/12.x/novavalue.md
+
+### `php artisan octane:frankenphp`
+
+Start the Octane FrankenPHP server
+
+```bash
+php artisan octane:frankenphp [--host [HOST]] [--port [PORT]] [--admin-host [ADMIN-HOST]] [--admin-port [ADMIN-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-host` (value optional) — The host the admin server should be available on; default: `localhost`
+- `--admin-port` (value optional) — The port the admin server should be available on; default: `2019`
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to; default: `127.0.0.1`
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed)
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/12.x/octanefrankenphp.md
+
+### `php artisan octane:install`
+
+Install the Octane components and resources
+
+```bash
+php artisan octane:install [--server [SERVER]] [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing configuration files
+- `--server` (value optional) — The server that should be used to serve the application
+
+Source: https://artisan.page/12.x/octaneinstall.md
+
+### `php artisan octane:reload`
+
+Reload the Octane workers
+
+```bash
+php artisan octane:reload [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/12.x/octanereload.md
+
+### `php artisan octane:roadrunner`
+
+Start the Octane RoadRunner server
+
+```bash
+php artisan octane:roadrunner [--host [HOST]] [--port [PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/12.x/octaneroadrunner.md
+
+### `php artisan octane:start`
+
+Start the Octane server
+
+```bash
+php artisan octane:start [--server [SERVER]] [--host [HOST]] [--port [PORT]] [--admin-port [ADMIN-PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-port` (value optional) — The port the admin server should be available on [FrankenPHP only]
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed) [FrankenPHP only]
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on [default: "8000"]
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--server` (value optional) — The server that should be used to serve the application
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests
+
+Source: https://artisan.page/12.x/octanestart.md
+
+### `php artisan octane:status`
+
+Get the current status of the Octane server
+
+```bash
+php artisan octane:status [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/12.x/octanestatus.md
+
+### `php artisan octane:stop`
+
+Stop the Octane server
+
+```bash
+php artisan octane:stop [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/12.x/octanestop.md
+
+### `php artisan octane:swoole`
+
+Start the Octane Swoole server
+
+```bash
+php artisan octane:swoole [--host [HOST]] [--port [PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--watch] [--poll]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks; default: `auto`
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/12.x/octaneswoole.md
+
+### `php artisan optimize`
+
+Cache framework bootstrap, configuration, and metadata to increase performance
+
+```bash
+php artisan optimize [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — Do not run the commands matching the key or name
+
+Source: https://artisan.page/12.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — The commands to skip
+
+Source: https://artisan.page/12.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/12.x/packagediscover.md
+
+### `php artisan pail`
+
+Tails the application logs
+
+```bash
+php artisan pail [--filter [FILTER]] [--message [MESSAGE]] [--level [LEVEL]] [--auth [AUTH]] [--user [USER]] [--timeout [TIMEOUT]]
+```
+
+Options:
+- `--auth` (value optional) — Filter the logs by the given authenticated ID
+- `--filter` (value optional) — Filter the logs by the given value
+- `--level` (value optional) — Filter the logs by the given level
+- `--message` (value optional) — Filter the logs by the given message
+- `--timeout` (value optional) — The maximum execution time in seconds; default: `3600`
+- `--user` (value optional) — Filter the logs by the given authenticated ID (alias for --auth)
+
+Source: https://artisan.page/12.x/pail.md
+
+### `php artisan passport:client`
+
+Create a client for issuing access tokens
+
+```bash
+php artisan passport:client [--personal] [--password] [--client] [--implicit] [--device] [--name [NAME]] [--provider [PROVIDER]] [--redirect_uri [REDIRECT_URI]] [--public]
+```
+
+Options:
+- `--client` — Create a client credentials grant client
+- `--device` — Create a device authorization grant client
+- `--implicit` — Create an implicit grant client
+- `--name` (value optional) — The name of the client
+- `--password` — Create a password grant client
+- `--personal` — Create a personal access token client
+- `--provider` (value optional) — The name of the user provider
+- `--public` — Create a public client (without secret)
+- `--redirect_uri` (value optional) — The URI to redirect to after authorization
+
+Source: https://artisan.page/12.x/passportclient.md
+
+### `php artisan passport:hash`
+
+Hash all of the existing secrets in the clients table
+
+```bash
+php artisan passport:hash [--force]
+```
+
+Options:
+- `--force` — Force the operation to run without confirmation prompt
+
+Source: https://artisan.page/12.x/passporthash.md
+
+### `php artisan passport:install`
+
+Run the commands necessary to prepare Passport for use
+
+```bash
+php artisan passport:install [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/12.x/passportinstall.md
+
+### `php artisan passport:keys`
+
+Create the encryption keys for API authentication
+
+```bash
+php artisan passport:keys [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/12.x/passportkeys.md
+
+### `php artisan passport:purge`
+
+Purge revoked and / or expired tokens and authentication codes
+
+```bash
+php artisan passport:purge [--revoked] [--expired] [--hours [HOURS]]
+```
+
+Options:
+- `--expired` — Only purge expired tokens and authentication codes
+- `--hours` (value optional) — The number of hours to retain expired tokens; default: `168`
+- `--revoked` — Only purge revoked tokens and authentication codes
+
+Source: https://artisan.page/12.x/passportpurge.md
+
+### `php artisan pennant:feature`
+
+Create a new feature class
+
+```bash
+php artisan pennant:feature [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the feature
+
+Options:
+- `--force` — Create the class even if the feature already exists
+
+Source: https://artisan.page/12.x/pennantfeature.md
+
+### `php artisan pennant:purge`
+
+Delete Pennant features from storage
+
+```bash
+php artisan pennant:purge [--except [EXCEPT]] [--except-registered] [--store [STORE]] [--] [<features>...]
+```
+
+Arguments:
+- `features` — The features to purge
+
+Options:
+- `--except` (value optional) — The features that should be excluded from purging
+- `--except-registered` — Purge all features except those registered
+- `--store` (value optional) — The store to purge the features from
+
+Aliases: `pennant:clear`
+
+Source: https://artisan.page/12.x/pennantpurge.md
+
+### `php artisan pulse:check`
+
+Take a snapshot of the current server's pulse
+
+```bash
+php artisan pulse:check [--once]
+```
+
+Options:
+- `--once` — Take a single snapshot
+
+Source: https://artisan.page/12.x/pulsecheck.md
+
+### `php artisan pulse:clear`
+
+Delete all Pulse data from storage
+
+```bash
+php artisan pulse:clear [--type [TYPE]] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--type` (value optional) — Only clear the specified type(s)
+
+Aliases: `pulse:purge`
+
+Source: https://artisan.page/12.x/pulseclear.md
+
+### `php artisan pulse:restart`
+
+Restart any running "work" and "check" commands
+
+```bash
+php artisan pulse:restart
+```
+
+Source: https://artisan.page/12.x/pulserestart.md
+
+### `php artisan pulse:work`
+
+Process incoming Pulse data from the ingest stream
+
+```bash
+php artisan pulse:work [--stop-when-empty]
+```
+
+Options:
+- `--stop-when-empty` — Stop when the stream is empty
+
+Source: https://artisan.page/12.x/pulsework.md
+
+### `php artisan queue:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan queue:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to clear
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/12.x/queueclear.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/12.x/queuefailed.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed job data
+
+Source: https://artisan.page/12.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/12.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--queue` (value optional) — The queue to listen on
+- `--rest` (value optional) — The number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — The number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — The number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/12.x/queuelisten.md
+
+### `php artisan queue:monitor`
+
+Monitor the size of the specified queues
+
+```bash
+php artisan queue:monitor [--max [MAX]] [--json] [--] <queues>
+```
+
+Arguments:
+- `queues` (required) — The names of the queues to monitor
+
+Options:
+- `--json` — Output the queue size as JSON
+- `--max` (value optional) — The maximum number of jobs that can be on the queue before an event is dispatched; default: `1000`
+
+Source: https://artisan.page/12.x/queuemonitor.md
+
+### `php artisan queue:pause`
+
+Pause job processing for a specific queue
+
+```bash
+php artisan queue:pause <queue>
+```
+
+Arguments:
+- `queue` (required) — The name of the queue to pause
+
+Source: https://artisan.page/12.x/queuepause.md
+
+### `php artisan queue:prune-batches`
+
+Prune stale entries from the batches database
+
+```bash
+php artisan queue:prune-batches [--hours [HOURS]] [--unfinished [UNFINISHED]] [--cancelled [CANCELLED]]
+```
+
+Options:
+- `--cancelled` (value optional) — The number of hours to retain cancelled batch data
+- `--hours` (value optional) — The number of hours to retain batch data; default: `24`
+- `--unfinished` (value optional) — The number of hours to retain unfinished batch data
+
+Source: https://artisan.page/12.x/queueprune-batches.md
+
+### `php artisan queue:prune-failed`
+
+Prune stale entries from the failed jobs table
+
+```bash
+php artisan queue:prune-failed [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed jobs data; default: `24`
+
+Source: https://artisan.page/12.x/queueprune-failed.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/12.x/queuerestart.md
+
+### `php artisan queue:resume`
+
+Resume job processing for a paused queue
+
+```bash
+php artisan queue:resume <queue>
+```
+
+Arguments:
+- `queue` (required) — The name of the queue that should resume processing
+
+Aliases: `queue:continue`
+
+Source: https://artisan.page/12.x/queueresume.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry [--queue [QUEUE]] [--range [RANGE]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the failed job or "all" to retry all jobs
+
+Options:
+- `--queue` (value optional) — Retry all of the failed jobs for the specified queue
+- `--range` (value optional) — Range of job IDs (numeric) to be retried (e.g. 1-5)
+
+Source: https://artisan.page/12.x/queueretry.md
+
+### `php artisan queue:retry-batch`
+
+Retry the failed jobs for a batch
+
+```bash
+php artisan queue:retry-batch [--isolated [ISOLATED]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the batch whose failed jobs should be retried
+
+Options:
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+
+Source: https://artisan.page/12.x/queueretry-batch.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--name [NAME]] [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--stop-when-empty-for [STOP-WHEN-EMPTY-FOR]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--json] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--json` — Output the queue worker information as JSON
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — The number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — The number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--stop-when-empty-for` (value optional) — Stop when no jobs have been processed for the given number of seconds; default: `0`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — The number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/12.x/queuework.md
+
+### `php artisan reload`
+
+Reload running services
+
+```bash
+php artisan reload [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — The commands to skip
+
+Source: https://artisan.page/12.x/reload.md
+
+### `php artisan reverb:install`
+
+Install the Reverb dependencies
+
+```bash
+php artisan reverb:install
+```
+
+Source: https://artisan.page/12.x/reverbinstall.md
+
+### `php artisan reverb:restart`
+
+Restart the Reverb server
+
+```bash
+php artisan reverb:restart
+```
+
+Source: https://artisan.page/12.x/reverbrestart.md
+
+### `php artisan reverb:start`
+
+Start the Reverb server
+
+```bash
+php artisan reverb:start [--host [HOST]] [--port [PORT]] [--path [PATH]] [--hostname [HOSTNAME]] [--debug]
+```
+
+Options:
+- `--debug` — Indicates whether debug messages should be displayed in the terminal
+- `--host` (value optional) — The IP address the server should bind to
+- `--hostname` (value optional) — The hostname the server is accessible from
+- `--path` (value optional) — The path the server should prefix to all routes
+- `--port` (value optional) — The port the server should listen on
+
+Source: https://artisan.page/12.x/reverbstart.md
+
+### `php artisan roster:scan`
+
+Detect packages & approaches in use and output as JSON
+
+```bash
+php artisan roster:scan <directory>
+```
+
+Arguments:
+- `directory` (required)
+
+Source: https://artisan.page/12.x/rosterscan.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/12.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/12.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--json] [--method [METHOD]] [--action [ACTION]] [--name [NAME]] [--domain [DOMAIN]] [--middleware [MIDDLEWARE]] [--path [PATH]] [--except-path [EXCEPT-PATH]] [-r|--reverse] [--sort [SORT]] [--except-vendor] [--only-vendor]
+```
+
+Options:
+- `--action` (value optional) — Filter the routes by action
+- `--domain` (value optional) — Filter the routes by domain
+- `--except-path` (value optional) — Do not display the routes matching the given path pattern
+- `--except-vendor` — Do not display routes defined by vendor packages
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--middleware` (value optional) — Filter the routes by middleware
+- `--name` (value optional) — Filter the routes by name
+- `--only-vendor` — Only display routes defined by vendor packages
+- `--path` (value optional) — Only show routes matching the given path pattern
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware, definition) to sort by; default: `uri`
+
+Source: https://artisan.page/12.x/routelist.md
+
+### `php artisan sail:add`
+
+Add a service to an existing Sail installation
+
+```bash
+php artisan sail:add [<services>]
+```
+
+Arguments:
+- `services` — The services that should be added
+
+Source: https://artisan.page/12.x/sailadd.md
+
+### `php artisan sail:install`
+
+Install Laravel Sail's default Docker Compose file
+
+```bash
+php artisan sail:install [--with [WITH]] [--devcontainer] [--php [PHP]]
+```
+
+Options:
+- `--devcontainer` — Create a .devcontainer configuration directory
+- `--php` (value optional) — The PHP version that should be used; default: `8.5`
+- `--with` (value optional) — The services that should be included in the installation
+
+Source: https://artisan.page/12.x/sailinstall.md
+
+### `php artisan sail:publish`
+
+Publish the Laravel Sail Docker files
+
+```bash
+php artisan sail:publish
+```
+
+Source: https://artisan.page/12.x/sailpublish.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens; default: `24`
+
+Source: https://artisan.page/12.x/sanctumprune-expired.md
+
+### `php artisan schedule:clear-cache`
+
+Delete the cached mutex files created by scheduler
+
+```bash
+php artisan schedule:clear-cache
+```
+
+Source: https://artisan.page/12.x/scheduleclear-cache.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/12.x/schedulefinish.md
+
+### `php artisan schedule:interrupt`
+
+Interrupt the current schedule run
+
+```bash
+php artisan schedule:interrupt
+```
+
+Source: https://artisan.page/12.x/scheduleinterrupt.md
+
+### `php artisan schedule:list`
+
+List all scheduled tasks
+
+```bash
+php artisan schedule:list [--timezone [TIMEZONE]] [--next] [--json]
+```
+
+Options:
+- `--json` — Output the scheduled tasks as JSON
+- `--next` — Sort the listed tasks by their next due date
+- `--timezone` (value optional) — The timezone that times should be displayed in
+
+Source: https://artisan.page/12.x/schedulelist.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run [--whisper]
+```
+
+Options:
+- `--whisper` — Do not output message indicating that no jobs were ready to run
+
+Source: https://artisan.page/12.x/schedulerun.md
+
+### `php artisan schedule:test`
+
+Run a scheduled command
+
+```bash
+php artisan schedule:test [--name [NAME]]
+```
+
+Options:
+- `--name` (value optional) — The name of the scheduled command to run
+
+Source: https://artisan.page/12.x/scheduletest.md
+
+### `php artisan schedule:work`
+
+Start the schedule worker
+
+```bash
+php artisan schedule:work [--run-output-file [RUN-OUTPUT-FILE]] [--whisper]
+```
+
+Options:
+- `--run-output-file` (value optional) — The file to direct <info>schedule:run</info> output to
+- `--whisper` — Do not output message indicating that no jobs were ready to run
+
+Source: https://artisan.page/12.x/schedulework.md
+
+### `php artisan schema:dump`
+
+Dump the given database schema
+
+```bash
+php artisan schema:dump [--database [DATABASE]] [--path [PATH]] [--prune]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path where the schema dump file should be stored
+- `--prune` — Delete all existing migration files
+
+Source: https://artisan.page/12.x/schemadump.md
+
+### `php artisan scout:delete-all-indexes`
+
+Delete all indexes
+
+```bash
+php artisan scout:delete-all-indexes
+```
+
+Source: https://artisan.page/12.x/scoutdelete-all-indexes.md
+
+### `php artisan scout:delete-index`
+
+Delete an index
+
+```bash
+php artisan scout:delete-index <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Source: https://artisan.page/12.x/scoutdelete-index.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required) — Class name of the model to flush
+
+Source: https://artisan.page/12.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [--fresh] [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+- `--fresh` — Flush the index before importing
+
+Source: https://artisan.page/12.x/scoutimport.md
+
+### `php artisan scout:index`
+
+Create an index
+
+```bash
+php artisan scout:index [-k|--key [KEY]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Options:
+- `--key` (value optional) — The name of the primary key
+
+Source: https://artisan.page/12.x/scoutindex.md
+
+### `php artisan scout:queue-import`
+
+Import the given model into the search index via chunked, queued jobs
+
+```bash
+php artisan scout:queue-import [--min [MIN]] [--max [MAX]] [-c|--chunk [CHUNK]] [--queue [QUEUE]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk queue
+
+Options:
+- `--chunk` (value optional) — The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)
+- `--max` (value optional) — The maximum ID to queue up to
+- `--min` (value optional) — The minimum ID to start queuing from
+- `--queue` (value optional) — The queue that should be used (Defaults to configuration value: `scout.queue.queue`)
+
+Source: https://artisan.page/12.x/scoutqueue-import.md
+
+### `php artisan scout:sync-index-settings`
+
+Sync your configured index settings with your search engine (Meilisearch)
+
+```bash
+php artisan scout:sync-index-settings [--driver [DRIVER]]
+```
+
+Options:
+- `--driver` (value optional) — The name of the search engine driver (Defaults to configuration value: `scout.driver`)
+
+Source: https://artisan.page/12.x/scoutsync-index-settings.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]] [--no-reload]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--no-reload` — Do not reload the development server on .env file changes
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/12.x/serve.md
+
+### `php artisan spark:install`
+
+Install all of the Spark resources
+
+```bash
+php artisan spark:install
+```
+
+Source: https://artisan.page/12.x/sparkinstall.md
+
+### `php artisan storage:link`
+
+Create the symbolic links configured for the application
+
+```bash
+php artisan storage:link [--relative] [--force]
+```
+
+Options:
+- `--force` — Recreate existing symbolic links
+- `--relative` — Create the symbolic link using relative paths
+
+Source: https://artisan.page/12.x/storagelink.md
+
+### `php artisan storage:unlink`
+
+Delete existing symbolic links configured for the application
+
+```bash
+php artisan storage:unlink
+```
+
+Source: https://artisan.page/12.x/storageunlink.md
+
+### `php artisan stub:publish`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan stub:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/12.x/stubpublish.md
+
+### `php artisan telescope:clear`
+
+Delete all Telescope data from storage
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/12.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/12.x/telescopeinstall.md
+
+### `php artisan telescope:pause`
+
+Pause all Telescope watchers
+
+```bash
+php artisan telescope:pause
+```
+
+Source: https://artisan.page/12.x/telescopepause.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]] [--keep-exceptions]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data; default: `24`
+- `--keep-exceptions` — Retain exception data
+
+Source: https://artisan.page/12.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/12.x/telescopepublish.md
+
+### `php artisan telescope:resume`
+
+Unpause all Telescope watchers
+
+```bash
+php artisan telescope:resume
+```
+
+Source: https://artisan.page/12.x/telescoperesume.md
+
+### `php artisan test`
+
+Run the application tests
+
+```bash
+php artisan test [--without-tty] [--compact] [--coverage] [--min [MIN]] [-p|--parallel] [--profile] [--recreate-databases] [--drop-databases] [--without-databases] [--without-cache]
+```
+
+Options:
+- `--compact` — Indicates whether the compact printer should be used
+- `--coverage` — Indicates whether code coverage information should be collected
+- `--drop-databases` — Indicates if the test databases should be dropped
+- `--min` (value optional) — Indicates the minimum threshold enforcement for code coverage
+- `--parallel` — Indicates if the tests should run in parallel
+- `--profile` — Lists top 10 slowest tests
+- `--recreate-databases` — Indicates if the test databases should be re-created
+- `--without-cache` — Indicates if cache configuration should be performed
+- `--without-databases` — Indicates if database configuration should be performed
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/12.x/test.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/12.x/tinker.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/12.x/up.md
+
+### `php artisan vapor:handle`
+
+```bash
+php artisan vapor:handle <payload>
+```
+
+Arguments:
+- `payload` (required)
+
+Source: https://artisan.page/12.x/vaporhandle.md
+
+### `php artisan vapor:health-check`
+
+Check the health of the Vapor application
+
+```bash
+php artisan vapor:health-check
+```
+
+Source: https://artisan.page/12.x/vaporhealth-check.md
+
+### `php artisan vapor:queue-failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan vapor:queue-failed [--limit [LIMIT]] [--page [PAGE]] [--id [ID]] [--queue [QUEUE]] [--query [QUERY]] [--start [START]]
+```
+
+Options:
+- `--id` (value optional) — The job ID filter by
+- `--limit` (value optional) — The number of failed jobs to return
+- `--page` (value optional) — The page of failed jobs to return; default: `1`
+- `--query` (value optional) — The search query to filter by
+- `--queue` (value optional) — The queue to filter by
+- `--start` (value optional) — The start timestamp to filter by
+
+Source: https://artisan.page/12.x/vaporqueue-failed.md
+
+### `php artisan vapor:schedule`
+
+Run the scheduled commands at the beginning of every minute
+
+```bash
+php artisan vapor:schedule
+```
+
+Source: https://artisan.page/12.x/vaporschedule.md
+
+### `php artisan vapor:work`
+
+Process a Vapor job
+
+```bash
+php artisan vapor:work [--delay [DELAY]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--force]
+```
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `0`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/12.x/vaporwork.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--existing] [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/12.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/12.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/12.x/viewclear.md
+
+### `php artisan volt:install`
+
+Install all of the Volt resources
+
+```bash
+php artisan volt:install
+```
+
+Source: https://artisan.page/12.x/voltinstall.md
+
+## Laravel 11.x
+
+254 documented commands.
+
+### `php artisan _complete`
+
+Internal command to provide shell completion suggestions
+
+```bash
+php artisan _complete [-s|--shell SHELL] [-i|--input INPUT] [-c|--current CURRENT] [-a|--api-version API-VERSION] [-S|--symfony SYMFONY]
+```
+
+Options:
+- `--api-version` (value required) — The API version of the completion script
+- `--current` (value required) — The index of the "input" array that the cursor is in (e.g. COMP_CWORD)
+- `--input` (value required) — An array of input tokens (e.g. COMP_WORDS or argv)
+- `--shell` (value required) — The shell type ("bash", "fish", "zsh")
+- `--symfony` (value required) — deprecated
+
+Source: https://artisan.page/11.x/_complete.md
+
+### `php artisan about`
+
+Display basic information about your application
+
+```bash
+php artisan about [--only [ONLY]] [--json]
+```
+
+Options:
+- `--json` — Output the information as JSON
+- `--only` (value optional) — The section to display
+
+Source: https://artisan.page/11.x/about.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/11.x/authclear-resets.md
+
+### `php artisan boost:add-skill`
+
+Add skills from a remote GitHub repository
+
+```bash
+php artisan boost:add-skill [--list] [--all] [--skill [SKILL]] [--force] [--skip-audit] [--] [<repo>]
+```
+
+Arguments:
+- `repo` — GitHub repository (owner/repo or full URL)
+
+Options:
+- `--all` — Install all skills
+- `--force` — Overwrite existing skills
+- `--list` — List available skills
+- `--skill` (value optional) — Specific skills to install
+- `--skip-audit` — Skip security audit
+
+Source: https://artisan.page/11.x/boostadd-skill.md
+
+### `php artisan boost:execute-tool`
+
+Execute a Boost MCP tool in isolation (internal command)
+
+```bash
+php artisan boost:execute-tool <tool> <arguments>
+```
+
+Arguments:
+- `tool` (required)
+- `arguments` (required)
+
+Source: https://artisan.page/11.x/boostexecute-tool.md
+
+### `php artisan boost:install`
+
+```bash
+php artisan boost:install [--guidelines] [--skills] [--mcp]
+```
+
+Options:
+- `--guidelines` — Install AI guidelines
+- `--mcp` — Install MCP server configuration
+- `--skills` — Install agent skills
+
+Source: https://artisan.page/11.x/boostinstall.md
+
+### `php artisan boost:list-skills`
+
+List all available skills in the current project
+
+```bash
+php artisan boost:list-skills
+```
+
+Source: https://artisan.page/11.x/boostlist-skills.md
+
+### `php artisan boost:mcp`
+
+Starts Laravel Boost (usually from mcp.json)
+
+```bash
+php artisan boost:mcp
+```
+
+Source: https://artisan.page/11.x/boostmcp.md
+
+### `php artisan boost:update`
+
+Update the Laravel Boost guidelines & skills to the latest guidance
+
+```bash
+php artisan boost:update [--discover] [--ignore-skills]
+```
+
+Options:
+- `--discover` — Discover and prompt for newly available guidelines and skills
+- `--ignore-skills` — Skip updating the skills directory
+
+Source: https://artisan.page/11.x/boostupdate.md
+
+### `php artisan breeze:install`
+
+Install the Breeze controllers and resources
+
+```bash
+php artisan breeze:install [--dark] [--pest] [--ssr] [--typescript] [--eslint] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (blade,livewire,livewire-functional,react,vue,api)
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--eslint` — Indicates if ESLint with Prettier should be installed
+- `--pest` — Indicate that Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--typescript` — Indicates if TypeScript is preferred for the Inertia stack
+
+Source: https://artisan.page/11.x/breezeinstall.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/11.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/11.x/cacheforget.md
+
+### `php artisan cache:prune-stale-tags`
+
+Prune stale cache tags from the cache (Redis only)
+
+```bash
+php artisan cache:prune-stale-tags [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to prune tags from
+
+Source: https://artisan.page/11.x/cacheprune-stale-tags.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/11.x/cashierwebhook.md
+
+### `php artisan channel:list`
+
+List all registered private broadcast channels
+
+```bash
+php artisan channel:list
+```
+
+Source: https://artisan.page/11.x/channellist.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/11.x/clear-compiled.md
+
+### `php artisan completion`
+
+Dump the shell completion script
+
+```bash
+php artisan completion [--debug] [--] [<shell>]
+```
+
+Arguments:
+- `shell` — The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+Options:
+- `--debug` — Tail the completion debug log
+
+Source: https://artisan.page/11.x/completion.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/11.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/11.x/configclear.md
+
+### `php artisan config:publish`
+
+Publish configuration files to your application
+
+```bash
+php artisan config:publish [--all] [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the configuration file to publish
+
+Options:
+- `--all` — Publish all configuration files
+- `--force` — Overwrite any existing configuration files
+
+Source: https://artisan.page/11.x/configpublish.md
+
+### `php artisan config:show`
+
+Display all of the values for a given configuration file or key
+
+```bash
+php artisan config:show <config>
+```
+
+Arguments:
+- `config` (required) — The configuration file or key to show
+
+Source: https://artisan.page/11.x/configshow.md
+
+### `php artisan db`
+
+Start a new database CLI session
+
+```bash
+php artisan db [--read] [--write] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The database connection that should be used
+
+Options:
+- `--read` — Connect to the read connection
+- `--write` — Connect to the write connection
+
+Source: https://artisan.page/11.x/db.md
+
+### `php artisan db:monitor`
+
+Monitor the number of connections on the specified database
+
+```bash
+php artisan db:monitor [--databases [DATABASES]] [--max [MAX]]
+```
+
+Options:
+- `--databases` (value optional) — The database connections to monitor
+- `--max` (value optional) — The maximum number of connections that can be open before an event is dispatched
+
+Source: https://artisan.page/11.x/dbmonitor.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force] [--] [<class>]
+```
+
+Arguments:
+- `class` — The class name of the root seeder
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `Database\Seeders\DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/11.x/dbseed.md
+
+### `php artisan db:show`
+
+Display information about the given database
+
+```bash
+php artisan db:show [--database [DATABASE]] [--json] [--counts] [--views] [--types]
+```
+
+Options:
+- `--counts` — Show the table row count <bg=red;options=bold> Note: This can be slow on large databases </>
+- `--database` (value optional) — The database connection
+- `--json` — Output the database information as JSON
+- `--types` — Show the user defined types
+- `--views` — Show the database views <bg=red;options=bold> Note: This can be slow on large databases </>
+
+Source: https://artisan.page/11.x/dbshow.md
+
+### `php artisan db:table`
+
+Display information about the given database table
+
+```bash
+php artisan db:table [--database [DATABASE]] [--json] [--] [<table>]
+```
+
+Arguments:
+- `table` — The name of the table
+
+Options:
+- `--database` (value optional) — The database connection
+- `--json` — Output the table information as JSON
+
+Source: https://artisan.page/11.x/dbtable.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/11.x/dbwipe.md
+
+### `php artisan docs`
+
+Access the Laravel documentation
+
+```bash
+php artisan docs [<page> [<section>]]
+```
+
+Arguments:
+- `page` — The documentation page to open
+- `section` — The section of the page to open
+
+Source: https://artisan.page/11.x/docs.md
+
+### `php artisan down`
+
+Put the application into maintenance / demo mode
+
+```bash
+php artisan down [--redirect [REDIRECT]] [--render [RENDER]] [--retry [RETRY]] [--refresh [REFRESH]] [--secret [SECRET]] [--with-secret] [--status [STATUS]]
+```
+
+Options:
+- `--redirect` (value optional) — The path that users should be redirected to
+- `--refresh` (value optional) — The number of seconds after which the browser may refresh
+- `--render` (value optional) — The view that should be prerendered for display during maintenance mode
+- `--retry` (value optional) — The number of seconds after which the request may be retried
+- `--secret` (value optional) — The secret phrase that may be used to bypass maintenance mode
+- `--status` (value optional) — The status code that should be used when returning the maintenance mode response; default: `503`
+- `--with-secret` — Generate a random secret phrase that may be used to bypass maintenance mode
+
+Source: https://artisan.page/11.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/11.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/11.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/11.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/11.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/11.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/11.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/11.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/11.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/11.x/env.md
+
+### `php artisan env:decrypt`
+
+Decrypt an environment file
+
+```bash
+php artisan env:decrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--force] [--path [PATH]] [--filename [FILENAME]]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be decrypted
+- `--filename` (value optional) — Filename of the decrypted file
+- `--force` — Overwrite the existing environment file
+- `--key` (value optional) — The encryption key
+- `--path` (value optional) — Path to write the decrypted file
+
+Source: https://artisan.page/11.x/envdecrypt.md
+
+### `php artisan env:encrypt`
+
+Encrypt an environment file
+
+```bash
+php artisan env:encrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--prune] [--force]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be encrypted
+- `--force` — Overwrite the existing encrypted environment file
+- `--key` (value optional) — The encryption key
+- `--prune` — Delete the original environment file
+
+Source: https://artisan.page/11.x/envencrypt.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/11.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/11.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/11.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+
+Source: https://artisan.page/11.x/eventlist.md
+
+### `php artisan fortify:install`
+
+Install all of the Fortify resources
+
+```bash
+php artisan fortify:install
+```
+
+Source: https://artisan.page/11.x/fortifyinstall.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/11.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/11.x/horizon.md
+
+### `php artisan horizon:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan horizon:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/11.x/horizonclear.md
+
+### `php artisan horizon:clear-metrics`
+
+Delete metrics for all jobs and queues
+
+```bash
+php artisan horizon:clear-metrics
+```
+
+Source: https://artisan.page/11.x/horizonclear-metrics.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/11.x/horizoncontinue.md
+
+### `php artisan horizon:continue-supervisor`
+
+Instruct the supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to resume
+
+Source: https://artisan.page/11.x/horizoncontinue-supervisor.md
+
+### `php artisan horizon:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan horizon:forget [--all] [--] [<id>]
+```
+
+Arguments:
+- `id` — The ID of the failed job
+
+Options:
+- `--all` — Delete all failed jobs
+
+Source: https://artisan.page/11.x/horizonforget.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/11.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/11.x/horizonlist.md
+
+### `php artisan horizon:listen`
+
+Run Horizon and automatically restart workers on file changes
+
+```bash
+php artisan horizon:listen [--environment [ENVIRONMENT]] [--poll]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+- `--poll` — Use polling for file watching
+
+Source: https://artisan.page/11.x/horizonlisten.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/11.x/horizonpause.md
+
+### `php artisan horizon:pause-supervisor`
+
+Pause a supervisor
+
+```bash
+php artisan horizon:pause-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to pause
+
+Source: https://artisan.page/11.x/horizonpause-supervisor.md
+
+### `php artisan horizon:publish`
+
+Publish all of the Horizon resources
+
+```bash
+php artisan horizon:publish
+```
+
+Source: https://artisan.page/11.x/horizonpublish.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge [--signal [SIGNAL]]
+```
+
+Options:
+- `--signal` (value optional) — The signal to send to the rogue processes; default: `SIGTERM`
+
+Source: https://artisan.page/11.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/11.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/11.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--auto-scaling-strategy [AUTO-SCALING-STRATEGY]] [--balance-cooldown [BALANCE-COOLDOWN]] [--balance-max-shift [BALANCE-MAX-SHIFT]] [--workers-name [WORKERS-NAME]] [--parent-id [PARENT-ID]] [--rest [REST]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--auto-scaling-strategy` (value optional) — If supervisor should scale by jobs or time to complete; default: `time`
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--balance-cooldown` (value optional) — The number of seconds to wait in between auto-scaling attempts; default: `3`
+- `--balance-max-shift` (value optional) — The maximum number of processes to increase or decrease per one scaling; default: `1`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping a child process; default: `0`
+- `--max-processes` (value optional) — The maximum number of total workers to start; default: `1`
+- `--max-time` (value optional) — The maximum number of seconds a child process should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue; default: `1`
+- `--nice` (value optional) — The process priority; default: `0`
+- `--parent-id` (value optional) — The parent process ID; default: `0`
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+- `--workers-name` (value optional) — The name that should be assigned to the workers; default: `default`
+
+Source: https://artisan.page/11.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisor-status`
+
+Show the status for a given supervisor
+
+```bash
+php artisan horizon:supervisor-status <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor
+
+Source: https://artisan.page/11.x/horizonsupervisor-status.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/11.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/11.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/11.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--stop-when-empty-for [STOP-WHEN-EMPTY-FOR]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--json] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--json` — Output the queue worker information as JSON
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--stop-when-empty-for` (value optional) — Stop when no jobs have been processed for the given number of seconds; default: `0`
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/11.x/horizonwork.md
+
+### `php artisan inertia:check-ssr`
+
+Check the Inertia SSR server health status
+
+```bash
+php artisan inertia:check-ssr
+```
+
+Source: https://artisan.page/11.x/inertiacheck-ssr.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/11.x/inertiamiddleware.md
+
+### `php artisan inertia:start-ssr`
+
+Start the Inertia SSR server
+
+```bash
+php artisan inertia:start-ssr [--runtime [RUNTIME]]
+```
+
+Options:
+- `--runtime` (value optional) — The runtime to use (e.g. `node`, `bun`, or an absolute path)
+
+Source: https://artisan.page/11.x/inertiastart-ssr.md
+
+### `php artisan inertia:stop-ssr`
+
+Stop the Inertia SSR server
+
+```bash
+php artisan inertia:stop-ssr
+```
+
+Source: https://artisan.page/11.x/inertiastop-ssr.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/11.x/inspire.md
+
+### `php artisan install:api`
+
+Create an API routes file and install Laravel Sanctum or Laravel Passport
+
+```bash
+php artisan install:api [--composer [COMPOSER]] [--force] [--passport] [--without-migration-prompt]
+```
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--force` — Overwrite any existing API routes file
+- `--passport` — Install Laravel Passport instead of Laravel Sanctum
+- `--without-migration-prompt` — Do not prompt to run pending migrations
+
+Source: https://artisan.page/11.x/installapi.md
+
+### `php artisan install:broadcasting`
+
+Create a broadcasting channel routes file
+
+```bash
+php artisan install:broadcasting [--composer [COMPOSER]] [--force] [--without-reverb] [--without-node]
+```
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--force` — Overwrite any existing broadcasting routes file
+- `--without-node` — Do not prompt to install Node dependencies
+- `--without-reverb` — Do not prompt to install Laravel Reverb
+
+Source: https://artisan.page/11.x/installbroadcasting.md
+
+### `php artisan invoke-serialized-closure`
+
+Invoke the given serialized closure
+
+```bash
+php artisan invoke-serialized-closure [<code>]
+```
+
+Arguments:
+- `code` — The serialized closure
+
+Source: https://artisan.page/11.x/invoke-serialized-closure.md
+
+### `php artisan jetstream:install`
+
+Install the Jetstream components and resources
+
+```bash
+php artisan jetstream:install [--dark] [--teams] [--api] [--verification] [--pest] [--ssr] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (inertia,livewire)
+
+Options:
+- `--api` — Indicates if API support should be installed
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--pest` — Indicates if Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--teams` — Indicates if team support should be installed
+- `--verification` — Indicates if email verification support should be installed
+
+Source: https://artisan.page/11.x/jetstreaminstall.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/11.x/keygenerate.md
+
+### `php artisan lang:publish`
+
+Publish all language files that are available for customization
+
+```bash
+php artisan lang:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/11.x/langpublish.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--short] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+- `--short` — To skip describing commands' arguments
+
+Source: https://artisan.page/11.x/list.md
+
+### `php artisan livewire:attribute`
+
+Create a new Livewire attribute class
+
+```bash
+php artisan livewire:attribute [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/11.x/livewireattribute.md
+
+### `php artisan livewire:config`
+
+Publish Livewire config file
+
+```bash
+php artisan livewire:config
+```
+
+Source: https://artisan.page/11.x/livewireconfig.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/11.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:convert`
+
+Convert a Livewire component between single-file and multi-file formats
+
+```bash
+php artisan livewire:convert [--sfc] [--mfc] [--test] [--emoji EMOJI] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--mfc` — Convert to multi-file component
+- `--sfc` — Convert to single-file component
+- `--test` — Create a test file when converting to multi-file (if one does not exist)
+
+Source: https://artisan.page/11.x/livewireconvert.md
+
+### `php artisan livewire:form`
+
+Create a new Livewire form class
+
+```bash
+php artisan livewire:form [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/11.x/livewireform.md
+
+### `php artisan livewire:layout`
+
+Create a new app layout file
+
+```bash
+php artisan livewire:layout [--force] [--stub [STUB]]
+```
+
+Options:
+- `--force`
+- `--stub` (value optional) — If you have several stubs, stored in subfolders
+
+Source: https://artisan.page/11.x/livewirelayout.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/11.x/livewiremake.md
+
+### `php artisan livewire:publish`
+
+Publish Livewire configuration
+
+```bash
+php artisan livewire:publish [--assets] [--config] [--pagination]
+```
+
+Options:
+- `--assets` — Indicates if Livewire's front-end assets should be published
+- `--config` — Indicates if Livewire's config file should be published
+- `--pagination` — Indicates if Livewire's pagination views should be published
+
+Source: https://artisan.page/11.x/livewirepublish.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/11.x/livewirestubs.md
+
+### `php artisan make:cache-table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan make:cache-table
+```
+
+Aliases: `cache:table`
+
+Source: https://artisan.page/11.x/makecache-table.md
+
+### `php artisan make:cast`
+
+Create a new custom Eloquent cast class
+
+```bash
+php artisan make:cast [-f|--force] [--inbound] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the cast
+
+Options:
+- `--force` — Create the class even if the cast already exists
+- `--inbound` — Generate an inbound cast class
+
+Source: https://artisan.page/11.x/makecast.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the channel
+
+Options:
+- `--force` — Create the class even if the channel already exists
+
+Source: https://artisan.page/11.x/makechannel.md
+
+### `php artisan make:class`
+
+Create a new class
+
+```bash
+php artisan make:class [-i|--invokable] [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the class already exists
+- `--invokable` — Generate a single method, invokable class
+
+Source: https://artisan.page/11.x/makeclass.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [-f|--force] [--command [COMMAND]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that will be used to invoke the class
+- `--force` — Create the class even if the console command already exists
+- `--pest` — Generate an accompanying Pest test for the Console command
+- `--phpunit` — Generate an accompanying PHPUnit test for the Console command
+- `--test` — Generate an accompanying Test test for the Console command
+
+Source: https://artisan.page/11.x/makecommand.md
+
+### `php artisan make:component`
+
+Create a new view component class
+
+```bash
+php artisan make:component [--inline] [--view] [--path PATH] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--force` — Create the class even if the component already exists
+- `--inline` — Create a component that renders an inline view
+- `--path` (value required) — The location where the component view should be created
+- `--pest` — Generate an accompanying Pest test for the Component
+- `--phpunit` — Generate an accompanying PHPUnit test for the Component
+- `--test` — Generate an accompanying Test test for the Component
+- `--view` — Create an anonymous component with only a view
+
+Source: https://artisan.page/11.x/makecomponent.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--type TYPE] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [-R|--requests] [-s|--singleton] [--creatable] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the controller
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller
+- `--creatable` — Indicate that a singleton resource should be creatable
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class
+- `--model` (value optional) — Generate a resource controller for the given model
+- `--parent` (value optional) — Generate a nested resource controller class
+- `--pest` — Generate an accompanying Pest test for the Controller
+- `--phpunit` — Generate an accompanying PHPUnit test for the Controller
+- `--requests` — Generate FormRequest classes for store and update
+- `--resource` — Generate a resource controller class
+- `--singleton` — Generate a singleton resource controller class
+- `--test` — Generate an accompanying Test test for the Controller
+- `--type` (value required) — Manually specify the controller stub file to use
+
+Source: https://artisan.page/11.x/makecontroller.md
+
+### `php artisan make:enum`
+
+Create a new enum
+
+```bash
+php artisan make:enum [-s|--string] [-i|--int] [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the enum
+
+Options:
+- `--force` — Create the enum even if the enum already exists
+- `--int` — Generate an integer backed enum.
+- `--string` — Generate a string backed enum.
+
+Source: https://artisan.page/11.x/makeenum.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the event
+
+Options:
+- `--force` — Create the class even if the event already exists
+
+Source: https://artisan.page/11.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [-f|--force] [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the exception
+
+Options:
+- `--force` — Create the class even if the exception already exists
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/11.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the factory
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/11.x/makefactory.md
+
+### `php artisan make:interface`
+
+Create a new interface
+
+```bash
+php artisan make:interface [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the interface
+
+Options:
+- `--force` — Create the interface even if the interface already exists
+
+Source: https://artisan.page/11.x/makeinterface.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [-f|--force] [--sync] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the job
+
+Options:
+- `--force` — Create the class even if the job already exists
+- `--pest` — Generate an accompanying Pest test for the Job
+- `--phpunit` — Generate an accompanying PHPUnit test for the Job
+- `--sync` — Indicates that job should be synchronous
+- `--test` — Generate an accompanying Test test for the Job
+
+Source: https://artisan.page/11.x/makejob.md
+
+### `php artisan make:job-middleware`
+
+Create a new job middleware class
+
+```bash
+php artisan make:job-middleware [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--force` — Create the class even if the job middleware already exists
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--phpunit` — Generate an accompanying PHPUnit test for the Middleware
+- `--test` — Generate an accompanying Test test for the Middleware
+
+Source: https://artisan.page/11.x/makejob-middleware.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [-f|--force] [--queued] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the listener
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--force` — Create the class even if the listener already exists
+- `--pest` — Generate an accompanying Pest test for the Listener
+- `--phpunit` — Generate an accompanying PHPUnit test for the Listener
+- `--queued` — Indicates the event listener should be queued
+- `--test` — Generate an accompanying Test test for the Listener
+
+Source: https://artisan.page/11.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/11.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--view [VIEW]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the mailable
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+- `--pest` — Generate an accompanying Pest test for the Mailable
+- `--phpunit` — Generate an accompanying PHPUnit test for the Mailable
+- `--test` — Generate an accompanying Test test for the Mailable
+- `--view` (value optional) — Create a new Blade template for the mailable
+
+Source: https://artisan.page/11.x/makemail.md
+
+### `php artisan make:mcp-app-resource`
+
+Create a new MCP app resource class and linked view
+
+```bash
+php artisan make:mcp-app-resource [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the appresource
+
+Options:
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/11.x/makemcp-app-resource.md
+
+### `php artisan make:mcp-prompt`
+
+Create a new MCP prompt class
+
+```bash
+php artisan make:mcp-prompt [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the prompt
+
+Options:
+- `--force` — Create the class even if the prompt already exists
+
+Source: https://artisan.page/11.x/makemcp-prompt.md
+
+### `php artisan make:mcp-resource`
+
+Create a new MCP resource class
+
+```bash
+php artisan make:mcp-resource [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/11.x/makemcp-resource.md
+
+### `php artisan make:mcp-server`
+
+Create a new MCP server class
+
+```bash
+php artisan make:mcp-server [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the server
+
+Options:
+- `--force` — Create the class even if the server already exists
+
+Source: https://artisan.page/11.x/makemcp-server.md
+
+### `php artisan make:mcp-tool`
+
+Create a new MCP tool class
+
+```bash
+php artisan make:mcp-tool [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the tool
+
+Options:
+- `--force` — Create the class even if the tool already exists
+
+Source: https://artisan.page/11.x/makemcp-tool.md
+
+### `php artisan make:middleware`
+
+Create a new HTTP middleware class
+
+```bash
+php artisan make:middleware [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--phpunit` — Generate an accompanying PHPUnit test for the Middleware
+- `--test` — Generate an accompanying Test test for the Middleware
+
+Source: https://artisan.page/11.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration (Deprecated)
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/11.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [--morph-pivot] [--policy] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [-R|--requests] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the model
+
+Options:
+- `--all` — Generate a migration, seeder, factory, policy, resource controller, and form request classes for the model
+- `--api` — Indicates if the generated controller should be an API resource controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--morph-pivot` — Indicates if the generated model should be a custom polymorphic intermediate table model
+- `--pest` — Generate an accompanying Pest test for the Model
+- `--phpunit` — Generate an accompanying PHPUnit test for the Model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--policy` — Create a new policy for the model
+- `--requests` — Create new form request classes and use them in the resource controller
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder for the model
+- `--test` — Generate an accompanying Test test for the Model
+
+Source: https://artisan.page/11.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the notification
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+- `--pest` — Generate an accompanying Pest test for the Notification
+- `--phpunit` — Generate an accompanying PHPUnit test for the Notification
+- `--test` — Generate an accompanying Test test for the Notification
+
+Source: https://artisan.page/11.x/makenotification.md
+
+### `php artisan make:notifications-table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan make:notifications-table
+```
+
+Aliases: `notifications:table`
+
+Source: https://artisan.page/11.x/makenotifications-table.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-f|--force] [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the observer
+
+Options:
+- `--force` — Create the class even if the observer already exists
+- `--model` (value optional) — The model that the observer applies to
+
+Source: https://artisan.page/11.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-f|--force] [-m|--model [MODEL]] [-g|--guard [GUARD]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--guard` (value optional) — The guard that the policy relies on
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/11.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the provider
+
+Options:
+- `--force` — Create the class even if the provider already exists
+
+Source: https://artisan.page/11.x/makeprovider.md
+
+### `php artisan make:queue-batches-table`
+
+Create a migration for the batches database table
+
+```bash
+php artisan make:queue-batches-table
+```
+
+Aliases: `queue:batches-table`
+
+Source: https://artisan.page/11.x/makequeue-batches-table.md
+
+### `php artisan make:queue-failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan make:queue-failed-table
+```
+
+Aliases: `queue:failed-table`
+
+Source: https://artisan.page/11.x/makequeue-failed-table.md
+
+### `php artisan make:queue-table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan make:queue-table
+```
+
+Aliases: `queue:table`
+
+Source: https://artisan.page/11.x/makequeue-table.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the request
+
+Options:
+- `--force` — Create the class even if the request already exists
+
+Source: https://artisan.page/11.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-f|--force] [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--collection` — Create a resource collection
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/11.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule [-f|--force] [-i|--implicit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the rule
+
+Options:
+- `--force` — Create the class even if the rule already exists
+- `--implicit` — Generate an implicit rule
+
+Source: https://artisan.page/11.x/makerule.md
+
+### `php artisan make:scope`
+
+Create a new scope class
+
+```bash
+php artisan make:scope [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the scope
+
+Options:
+- `--force` — Create the class even if the scope already exists
+
+Source: https://artisan.page/11.x/makescope.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the seeder
+
+Source: https://artisan.page/11.x/makeseeder.md
+
+### `php artisan make:session-table`
+
+Create a migration for the session database table
+
+```bash
+php artisan make:session-table
+```
+
+Aliases: `session:table`
+
+Source: https://artisan.page/11.x/makesession-table.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [-f|--force] [-u|--unit] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the test
+
+Options:
+- `--force` — Create the test even if the test already exists
+- `--pest` — Create a Pest test
+- `--phpunit` — Create a PHPUnit test
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/11.x/maketest.md
+
+### `php artisan make:trait`
+
+Create a new trait
+
+```bash
+php artisan make:trait [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the trait
+
+Options:
+- `--force` — Create the trait even if the trait already exists
+
+Source: https://artisan.page/11.x/maketrait.md
+
+### `php artisan make:view`
+
+Create a new view
+
+```bash
+php artisan make:view [--extension [EXTENSION]] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the view
+
+Options:
+- `--extension` (value optional) — The extension of the generated view; default: `blade.php`
+- `--force` — Create the view even if the view already exists
+- `--pest` — Generate an accompanying Pest test for the View
+- `--phpunit` — Generate an accompanying PHPUnit test for the View
+- `--test` — Generate an accompanying Test test for the View
+
+Source: https://artisan.page/11.x/makeview.md
+
+### `php artisan make:volt`
+
+Create a new Volt component
+
+```bash
+php artisan make:volt [--class] [--functional] [-f|--force] [--test] [--pest] [--phpunit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the volt component
+
+Options:
+- `--class` — Create a class based component
+- `--force` — Create the Volt component even if the component already exists
+- `--functional` — Create a functional component
+- `--pest` — Generate an accompanying Pest test for the Volt component
+- `--phpunit` — Generate an accompanying PHPUnit test for the Volt component
+- `--test` — Generate an accompanying Test test for the Volt component
+
+Source: https://artisan.page/11.x/makevolt.md
+
+### `php artisan mcp:inspector`
+
+Open the MCP Inspector tool to debug and test MCP Servers
+
+```bash
+php artisan mcp:inspector [--host [HOST]] [--port [PORT]] [--] <handle>
+```
+
+Arguments:
+- `handle` (required) — The handle or route of the MCP server to inspect.
+
+Options:
+- `--host` (value optional) — The host the inspector should bind to
+- `--port` (value optional) — The port the inspector should bind to
+
+Source: https://artisan.page/11.x/mcpinspector.md
+
+### `php artisan mcp:start`
+
+Start the MCP Server for a given handle
+
+```bash
+php artisan mcp:start <handle>
+```
+
+Arguments:
+- `handle` (required) — The handle of the MCP server to start.
+
+Source: https://artisan.page/11.x/mcpstart.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--pretend] [--seed] [--seeder [SEEDER]] [--step] [--graceful] [--isolated [ISOLATED]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--graceful` — Return a successful exit code even if an error occurs
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/11.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/11.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/11.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/11.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/11.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]] [--batch BATCH]
+```
+
+Options:
+- `--batch` (value required) — The batch of migrations (identified by their batch number) to be reverted
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/11.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--pending [PENDING]] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--pending` (value optional) — Only list pending migrations
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/11.x/migratestatus.md
+
+### `php artisan model:prune`
+
+Prune models that are no longer needed
+
+```bash
+php artisan model:prune [--model [MODEL]] [--except [EXCEPT]] [--path [PATH]] [--chunk [CHUNK]] [--pretend]
+```
+
+Options:
+- `--chunk` (value optional) — The number of models to retrieve per chunk of models to be deleted; default: `1000`
+- `--except` (value optional) — Class names of the models to be excluded from pruning
+- `--model` (value optional) — Class names of the models to be pruned
+- `--path` (value optional) — Absolute path(s) to directories where models are located
+- `--pretend` — Display the number of prunable records found instead of deleting them
+
+Source: https://artisan.page/11.x/modelprune.md
+
+### `php artisan model:show`
+
+Show information about an Eloquent model
+
+```bash
+php artisan model:show [--database [DATABASE]] [--json] [--] <model>
+```
+
+Arguments:
+- `model` (required) — The model to show
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--json` — Output the model as JSON
+
+Source: https://artisan.page/11.x/modelshow.md
+
+### `php artisan nightwatch:agent`
+
+Run the Nightwatch agent.
+
+```bash
+php artisan nightwatch:agent [--listen-on [LISTEN-ON]] [--auth-connection-timeout [AUTH-CONNECTION-TIMEOUT]] [--auth-timeout [AUTH-TIMEOUT]] [--ingest-connection-timeout [INGEST-CONNECTION-TIMEOUT]] [--ingest-timeout [INGEST-TIMEOUT]] [--server [SERVER]] [--silent]
+```
+
+Options:
+- `--auth-connection-timeout` (value optional)
+- `--auth-timeout` (value optional)
+- `--ingest-connection-timeout` (value optional)
+- `--ingest-timeout` (value optional)
+- `--listen-on` (value optional)
+- `--server` (value optional)
+- `--silent` — Do not output any message
+
+Source: https://artisan.page/11.x/nightwatchagent.md
+
+### `php artisan nightwatch:deploy`
+
+Send deployment metadata to Nightwatch.
+
+```bash
+php artisan nightwatch:deploy [--ref [REF]] [--name [NAME]] [--url [URL]] [--timestamp [TIMESTAMP]] [--] [<deploy>]
+```
+
+Arguments:
+- `deploy` — A unique value for the deploy <comment>[default: `NIGHTWATCH_DEPLOY`]</comment>
+
+Options:
+- `--name` (value optional) — The human-readable name of the deploy
+- `--ref` (value optional) — The git ref (tag or hash) of the deploy
+- `--timestamp` (value optional) — The timestamp of the deploy <comment>[default: `now()`]</comment>
+- `--url` (value optional) — A URL with information related to the deploy
+
+Source: https://artisan.page/11.x/nightwatchdeploy.md
+
+### `php artisan nightwatch:status`
+
+Get the current status of the Nightwatch agent.
+
+```bash
+php artisan nightwatch:status
+```
+
+Source: https://artisan.page/11.x/nightwatchstatus.md
+
+### `php artisan nova:action`
+
+Create a new action class
+
+```bash
+php artisan nova:action [--destructive] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the action
+
+Options:
+- `--destructive` — Indicate that the action deletes / destroys resources
+- `--queued` — Indicates the action should be queued
+
+Source: https://artisan.page/11.x/novaaction.md
+
+### `php artisan nova:asset`
+
+Create a new asset
+
+```bash
+php artisan nova:asset <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/11.x/novaasset.md
+
+### `php artisan nova:base-resource`
+
+Create a new base resource class
+
+```bash
+php artisan nova:base-resource <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Source: https://artisan.page/11.x/novabase-resource.md
+
+### `php artisan nova:card`
+
+Create a new card
+
+```bash
+php artisan nova:card <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/11.x/novacard.md
+
+### `php artisan nova:check-license`
+
+Verify your Nova license key
+
+```bash
+php artisan nova:check-license
+```
+
+Source: https://artisan.page/11.x/novacheck-license.md
+
+### `php artisan nova:custom-filter`
+
+Create a new custom filter
+
+```bash
+php artisan nova:custom-filter <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/11.x/novacustom-filter.md
+
+### `php artisan nova:dashboard`
+
+Create a new dashboard.
+
+```bash
+php artisan nova:dashboard <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/11.x/novadashboard.md
+
+### `php artisan nova:field`
+
+Create a new field
+
+```bash
+php artisan nova:field <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/11.x/novafield.md
+
+### `php artisan nova:filter`
+
+Create a new filter class
+
+```bash
+php artisan nova:filter [--boolean] [--date] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the filter
+
+Options:
+- `--boolean` — Indicates if the generated filter should be a boolean filter
+- `--date` — Indicates if the generated filter should be a date filter
+
+Source: https://artisan.page/11.x/novafilter.md
+
+### `php artisan nova:install`
+
+Install all of the Nova resources
+
+```bash
+php artisan nova:install
+```
+
+Source: https://artisan.page/11.x/novainstall.md
+
+### `php artisan nova:lens`
+
+Create a new lens class
+
+```bash
+php artisan nova:lens <name>
+```
+
+Arguments:
+- `name` (required) — The name of the lens
+
+Source: https://artisan.page/11.x/novalens.md
+
+### `php artisan nova:partition`
+
+Create a new metric (partition) class
+
+```bash
+php artisan nova:partition <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/11.x/novapartition.md
+
+### `php artisan nova:policy`
+
+Create a new policy class
+
+```bash
+php artisan nova:policy [-f|--force] [-m|--resource [RESOURCE]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--resource` (value optional) — The resource that the policy applies to
+
+Source: https://artisan.page/11.x/novapolicy.md
+
+### `php artisan nova:progress`
+
+Create a new metric (progress) class
+
+```bash
+php artisan nova:progress <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/11.x/novaprogress.md
+
+### `php artisan nova:publish`
+
+Publish all of the Nova resources
+
+```bash
+php artisan nova:publish [-f|--force] [--fortify|--no-fortify]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+- `--fortify` — Publish Laravel Fortify features
+
+Source: https://artisan.page/11.x/novapublish.md
+
+### `php artisan nova:repeatable`
+
+Create a new repeatable class
+
+```bash
+php artisan nova:repeatable [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the repeatable
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/11.x/novarepeatable.md
+
+### `php artisan nova:resource`
+
+Create a new resource class
+
+```bash
+php artisan nova:resource [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/11.x/novaresource.md
+
+### `php artisan nova:resource-tool`
+
+Create a new resource tool
+
+```bash
+php artisan nova:resource-tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/11.x/novaresource-tool.md
+
+### `php artisan nova:stubs`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan nova:stubs [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/11.x/novastubs.md
+
+### `php artisan nova:table`
+
+Create a new metric (table) class
+
+```bash
+php artisan nova:table <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/11.x/novatable.md
+
+### `php artisan nova:tool`
+
+Create a new tool
+
+```bash
+php artisan nova:tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/11.x/novatool.md
+
+### `php artisan nova:translate`
+
+Create translation files for Nova
+
+```bash
+php artisan nova:translate [--force] [--] <language>
+```
+
+Arguments:
+- `language` (required)
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/11.x/novatranslate.md
+
+### `php artisan nova:trend`
+
+Create a new metric (trend) class
+
+```bash
+php artisan nova:trend <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/11.x/novatrend.md
+
+### `php artisan nova:user`
+
+Create a new user
+
+```bash
+php artisan nova:user
+```
+
+Source: https://artisan.page/11.x/novauser.md
+
+### `php artisan nova:value`
+
+Create a new metric (single value) class
+
+```bash
+php artisan nova:value <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/11.x/novavalue.md
+
+### `php artisan octane:frankenphp`
+
+Start the Octane FrankenPHP server
+
+```bash
+php artisan octane:frankenphp [--host [HOST]] [--port [PORT]] [--admin-host [ADMIN-HOST]] [--admin-port [ADMIN-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-host` (value optional) — The host the admin server should be available on; default: `localhost`
+- `--admin-port` (value optional) — The port the admin server should be available on; default: `2019`
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to; default: `127.0.0.1`
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed)
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/11.x/octanefrankenphp.md
+
+### `php artisan octane:install`
+
+Install the Octane components and resources
+
+```bash
+php artisan octane:install [--server [SERVER]] [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing configuration files
+- `--server` (value optional) — The server that should be used to serve the application
+
+Source: https://artisan.page/11.x/octaneinstall.md
+
+### `php artisan octane:reload`
+
+Reload the Octane workers
+
+```bash
+php artisan octane:reload [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/11.x/octanereload.md
+
+### `php artisan octane:roadrunner`
+
+Start the Octane RoadRunner server
+
+```bash
+php artisan octane:roadrunner [--host [HOST]] [--port [PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/11.x/octaneroadrunner.md
+
+### `php artisan octane:start`
+
+Start the Octane server
+
+```bash
+php artisan octane:start [--server [SERVER]] [--host [HOST]] [--port [PORT]] [--admin-port [ADMIN-PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-port` (value optional) — The port the admin server should be available on [FrankenPHP only]
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed) [FrankenPHP only]
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on [default: "8000"]
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--server` (value optional) — The server that should be used to serve the application
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests
+
+Source: https://artisan.page/11.x/octanestart.md
+
+### `php artisan octane:status`
+
+Get the current status of the Octane server
+
+```bash
+php artisan octane:status [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/11.x/octanestatus.md
+
+### `php artisan octane:stop`
+
+Stop the Octane server
+
+```bash
+php artisan octane:stop [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/11.x/octanestop.md
+
+### `php artisan octane:swoole`
+
+Start the Octane Swoole server
+
+```bash
+php artisan octane:swoole [--host [HOST]] [--port [PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--watch] [--poll]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks; default: `auto`
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/11.x/octaneswoole.md
+
+### `php artisan optimize`
+
+Cache framework bootstrap, configuration, and metadata to increase performance
+
+```bash
+php artisan optimize [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — Do not run the commands matching the key or name
+
+Source: https://artisan.page/11.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear [-e|--except [EXCEPT]]
+```
+
+Options:
+- `--except` (value optional) — The commands to skip
+
+Source: https://artisan.page/11.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/11.x/packagediscover.md
+
+### `php artisan pail`
+
+Tails the application logs
+
+```bash
+php artisan pail [--filter [FILTER]] [--message [MESSAGE]] [--level [LEVEL]] [--auth [AUTH]] [--user [USER]] [--timeout [TIMEOUT]]
+```
+
+Options:
+- `--auth` (value optional) — Filter the logs by the given authenticated ID
+- `--filter` (value optional) — Filter the logs by the given value
+- `--level` (value optional) — Filter the logs by the given level
+- `--message` (value optional) — Filter the logs by the given message
+- `--timeout` (value optional) — The maximum execution time in seconds; default: `3600`
+- `--user` (value optional) — Filter the logs by the given authenticated ID (alias for --auth)
+
+Source: https://artisan.page/11.x/pail.md
+
+### `php artisan passport:client`
+
+Create a client for issuing access tokens
+
+```bash
+php artisan passport:client [--personal] [--password] [--client] [--implicit] [--device] [--name [NAME]] [--provider [PROVIDER]] [--redirect_uri [REDIRECT_URI]] [--public]
+```
+
+Options:
+- `--client` — Create a client credentials grant client
+- `--device` — Create a device authorization grant client
+- `--implicit` — Create an implicit grant client
+- `--name` (value optional) — The name of the client
+- `--password` — Create a password grant client
+- `--personal` — Create a personal access token client
+- `--provider` (value optional) — The name of the user provider
+- `--public` — Create a public client (without secret)
+- `--redirect_uri` (value optional) — The URI to redirect to after authorization
+
+Source: https://artisan.page/11.x/passportclient.md
+
+### `php artisan passport:hash`
+
+Hash all of the existing secrets in the clients table
+
+```bash
+php artisan passport:hash [--force]
+```
+
+Options:
+- `--force` — Force the operation to run without confirmation prompt
+
+Source: https://artisan.page/11.x/passporthash.md
+
+### `php artisan passport:install`
+
+Run the commands necessary to prepare Passport for use
+
+```bash
+php artisan passport:install [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/11.x/passportinstall.md
+
+### `php artisan passport:keys`
+
+Create the encryption keys for API authentication
+
+```bash
+php artisan passport:keys [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/11.x/passportkeys.md
+
+### `php artisan passport:purge`
+
+Purge revoked and / or expired tokens and authentication codes
+
+```bash
+php artisan passport:purge [--revoked] [--expired] [--hours [HOURS]]
+```
+
+Options:
+- `--expired` — Only purge expired tokens and authentication codes
+- `--hours` (value optional) — The number of hours to retain expired tokens; default: `168`
+- `--revoked` — Only purge revoked tokens and authentication codes
+
+Source: https://artisan.page/11.x/passportpurge.md
+
+### `php artisan pennant:feature`
+
+Create a new feature class
+
+```bash
+php artisan pennant:feature [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the feature
+
+Options:
+- `--force` — Create the class even if the feature already exists
+
+Source: https://artisan.page/11.x/pennantfeature.md
+
+### `php artisan pennant:purge`
+
+Delete Pennant features from storage
+
+```bash
+php artisan pennant:purge [--except [EXCEPT]] [--except-registered] [--store [STORE]] [--] [<features>...]
+```
+
+Arguments:
+- `features` — The features to purge
+
+Options:
+- `--except` (value optional) — The features that should be excluded from purging
+- `--except-registered` — Purge all features except those registered
+- `--store` (value optional) — The store to purge the features from
+
+Aliases: `pennant:clear`
+
+Source: https://artisan.page/11.x/pennantpurge.md
+
+### `php artisan pulse:check`
+
+Take a snapshot of the current server's pulse
+
+```bash
+php artisan pulse:check [--once]
+```
+
+Options:
+- `--once` — Take a single snapshot
+
+Source: https://artisan.page/11.x/pulsecheck.md
+
+### `php artisan pulse:clear`
+
+Delete all Pulse data from storage
+
+```bash
+php artisan pulse:clear [--type [TYPE]] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--type` (value optional) — Only clear the specified type(s)
+
+Aliases: `pulse:purge`
+
+Source: https://artisan.page/11.x/pulseclear.md
+
+### `php artisan pulse:restart`
+
+Restart any running "work" and "check" commands
+
+```bash
+php artisan pulse:restart
+```
+
+Source: https://artisan.page/11.x/pulserestart.md
+
+### `php artisan pulse:work`
+
+Process incoming Pulse data from the ingest stream
+
+```bash
+php artisan pulse:work [--stop-when-empty]
+```
+
+Options:
+- `--stop-when-empty` — Stop when the stream is empty
+
+Source: https://artisan.page/11.x/pulsework.md
+
+### `php artisan queue:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan queue:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to clear
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/11.x/queueclear.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/11.x/queuefailed.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed job data
+
+Source: https://artisan.page/11.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/11.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--queue` (value optional) — The queue to listen on
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/11.x/queuelisten.md
+
+### `php artisan queue:monitor`
+
+Monitor the size of the specified queues
+
+```bash
+php artisan queue:monitor [--max [MAX]] [--] <queues>
+```
+
+Arguments:
+- `queues` (required) — The names of the queues to monitor
+
+Options:
+- `--max` (value optional) — The maximum number of jobs that can be on the queue before an event is dispatched; default: `1000`
+
+Source: https://artisan.page/11.x/queuemonitor.md
+
+### `php artisan queue:prune-batches`
+
+Prune stale entries from the batches database
+
+```bash
+php artisan queue:prune-batches [--hours [HOURS]] [--unfinished [UNFINISHED]] [--cancelled [CANCELLED]]
+```
+
+Options:
+- `--cancelled` (value optional) — The number of hours to retain cancelled batch data
+- `--hours` (value optional) — The number of hours to retain batch data; default: `24`
+- `--unfinished` (value optional) — The number of hours to retain unfinished batch data
+
+Source: https://artisan.page/11.x/queueprune-batches.md
+
+### `php artisan queue:prune-failed`
+
+Prune stale entries from the failed jobs table
+
+```bash
+php artisan queue:prune-failed [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed jobs data; default: `24`
+
+Source: https://artisan.page/11.x/queueprune-failed.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/11.x/queuerestart.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry [--queue [QUEUE]] [--range [RANGE]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the failed job or "all" to retry all jobs
+
+Options:
+- `--queue` (value optional) — Retry all of the failed jobs for the specified queue
+- `--range` (value optional) — Range of job IDs (numeric) to be retried (e.g. 1-5)
+
+Source: https://artisan.page/11.x/queueretry.md
+
+### `php artisan queue:retry-batch`
+
+Retry the failed jobs for a batch
+
+```bash
+php artisan queue:retry-batch [--isolated [ISOLATED]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the batch whose failed jobs should be retried
+
+Options:
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+
+Source: https://artisan.page/11.x/queueretry-batch.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--name [NAME]] [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--stop-when-empty-for [STOP-WHEN-EMPTY-FOR]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--json] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--json` — Output the queue worker information as JSON
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--stop-when-empty-for` (value optional) — Stop when no jobs have been processed for the given number of seconds; default: `0`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/11.x/queuework.md
+
+### `php artisan reverb:install`
+
+Install the Reverb dependencies
+
+```bash
+php artisan reverb:install
+```
+
+Source: https://artisan.page/11.x/reverbinstall.md
+
+### `php artisan reverb:restart`
+
+Restart the Reverb server
+
+```bash
+php artisan reverb:restart
+```
+
+Source: https://artisan.page/11.x/reverbrestart.md
+
+### `php artisan reverb:start`
+
+Start the Reverb server
+
+```bash
+php artisan reverb:start [--host [HOST]] [--port [PORT]] [--path [PATH]] [--hostname [HOSTNAME]] [--debug]
+```
+
+Options:
+- `--debug` — Indicates whether debug messages should be displayed in the terminal
+- `--host` (value optional) — The IP address the server should bind to
+- `--hostname` (value optional) — The hostname the server is accessible from
+- `--path` (value optional) — The path the server should prefix to all routes
+- `--port` (value optional) — The port the server should listen on
+
+Source: https://artisan.page/11.x/reverbstart.md
+
+### `php artisan roster:scan`
+
+Detect packages & approaches in use and output as JSON
+
+```bash
+php artisan roster:scan <directory>
+```
+
+Arguments:
+- `directory` (required)
+
+Source: https://artisan.page/11.x/rosterscan.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/11.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/11.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--json] [--method [METHOD]] [--action [ACTION]] [--name [NAME]] [--domain [DOMAIN]] [--path [PATH]] [--except-path [EXCEPT-PATH]] [-r|--reverse] [--sort [SORT]] [--except-vendor] [--only-vendor]
+```
+
+Options:
+- `--action` (value optional) — Filter the routes by action
+- `--domain` (value optional) — Filter the routes by domain
+- `--except-path` (value optional) — Do not display the routes matching the given path pattern
+- `--except-vendor` — Do not display routes defined by vendor packages
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--name` (value optional) — Filter the routes by name
+- `--only-vendor` — Only display routes defined by vendor packages
+- `--path` (value optional) — Only show routes matching the given path pattern
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware, definition) to sort by; default: `uri`
+
+Source: https://artisan.page/11.x/routelist.md
+
+### `php artisan sail:add`
+
+Add a service to an existing Sail installation
+
+```bash
+php artisan sail:add [<services>]
+```
+
+Arguments:
+- `services` — The services that should be added
+
+Source: https://artisan.page/11.x/sailadd.md
+
+### `php artisan sail:install`
+
+Install Laravel Sail's default Docker Compose file
+
+```bash
+php artisan sail:install [--with [WITH]] [--devcontainer] [--php [PHP]]
+```
+
+Options:
+- `--devcontainer` — Create a .devcontainer configuration directory
+- `--php` (value optional) — The PHP version that should be used; default: `8.5`
+- `--with` (value optional) — The services that should be included in the installation
+
+Source: https://artisan.page/11.x/sailinstall.md
+
+### `php artisan sail:publish`
+
+Publish the Laravel Sail Docker files
+
+```bash
+php artisan sail:publish
+```
+
+Source: https://artisan.page/11.x/sailpublish.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens; default: `24`
+
+Source: https://artisan.page/11.x/sanctumprune-expired.md
+
+### `php artisan schedule:clear-cache`
+
+Delete the cached mutex files created by scheduler
+
+```bash
+php artisan schedule:clear-cache
+```
+
+Source: https://artisan.page/11.x/scheduleclear-cache.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/11.x/schedulefinish.md
+
+### `php artisan schedule:interrupt`
+
+Interrupt the current schedule run
+
+```bash
+php artisan schedule:interrupt
+```
+
+Source: https://artisan.page/11.x/scheduleinterrupt.md
+
+### `php artisan schedule:list`
+
+List all scheduled tasks
+
+```bash
+php artisan schedule:list [--timezone [TIMEZONE]] [--next] [--json]
+```
+
+Options:
+- `--json` — Output the scheduled tasks as JSON
+- `--next` — Sort the listed tasks by their next due date
+- `--timezone` (value optional) — The timezone that times should be displayed in
+
+Source: https://artisan.page/11.x/schedulelist.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run
+```
+
+Source: https://artisan.page/11.x/schedulerun.md
+
+### `php artisan schedule:test`
+
+Run a scheduled command
+
+```bash
+php artisan schedule:test [--name [NAME]]
+```
+
+Options:
+- `--name` (value optional) — The name of the scheduled command to run
+
+Source: https://artisan.page/11.x/scheduletest.md
+
+### `php artisan schedule:work`
+
+Start the schedule worker
+
+```bash
+php artisan schedule:work [--run-output-file [RUN-OUTPUT-FILE]]
+```
+
+Options:
+- `--run-output-file` (value optional) — The file to direct <info>schedule:run</info> output to
+
+Source: https://artisan.page/11.x/schedulework.md
+
+### `php artisan schema:dump`
+
+Dump the given database schema
+
+```bash
+php artisan schema:dump [--database [DATABASE]] [--path [PATH]] [--prune]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path where the schema dump file should be stored
+- `--prune` — Delete all existing migration files
+
+Source: https://artisan.page/11.x/schemadump.md
+
+### `php artisan scout:delete-all-indexes`
+
+Delete all indexes
+
+```bash
+php artisan scout:delete-all-indexes
+```
+
+Source: https://artisan.page/11.x/scoutdelete-all-indexes.md
+
+### `php artisan scout:delete-index`
+
+Delete an index
+
+```bash
+php artisan scout:delete-index <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Source: https://artisan.page/11.x/scoutdelete-index.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required) — Class name of the model to flush
+
+Source: https://artisan.page/11.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [--fresh] [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+- `--fresh` — Flush the index before importing
+
+Source: https://artisan.page/11.x/scoutimport.md
+
+### `php artisan scout:index`
+
+Create an index
+
+```bash
+php artisan scout:index [-k|--key [KEY]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Options:
+- `--key` (value optional) — The name of the primary key
+
+Source: https://artisan.page/11.x/scoutindex.md
+
+### `php artisan scout:queue-import`
+
+Import the given model into the search index via chunked, queued jobs
+
+```bash
+php artisan scout:queue-import [--min [MIN]] [--max [MAX]] [-c|--chunk [CHUNK]] [--queue [QUEUE]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk queue
+
+Options:
+- `--chunk` (value optional) — The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)
+- `--max` (value optional) — The maximum ID to queue up to
+- `--min` (value optional) — The minimum ID to start queuing from
+- `--queue` (value optional) — The queue that should be used (Defaults to configuration value: `scout.queue.queue`)
+
+Source: https://artisan.page/11.x/scoutqueue-import.md
+
+### `php artisan scout:sync-index-settings`
+
+Sync your configured index settings with your search engine (Meilisearch)
+
+```bash
+php artisan scout:sync-index-settings [--driver [DRIVER]]
+```
+
+Options:
+- `--driver` (value optional) — The name of the search engine driver (Defaults to configuration value: `scout.driver`)
+
+Source: https://artisan.page/11.x/scoutsync-index-settings.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]] [--no-reload]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--no-reload` — Do not reload the development server on .env file changes
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/11.x/serve.md
+
+### `php artisan spark:install`
+
+Install all of the Spark resources
+
+```bash
+php artisan spark:install
+```
+
+Source: https://artisan.page/11.x/sparkinstall.md
+
+### `php artisan storage:link`
+
+Create the symbolic links configured for the application
+
+```bash
+php artisan storage:link [--relative] [--force]
+```
+
+Options:
+- `--force` — Recreate existing symbolic links
+- `--relative` — Create the symbolic link using relative paths
+
+Source: https://artisan.page/11.x/storagelink.md
+
+### `php artisan storage:unlink`
+
+Delete existing symbolic links configured for the application
+
+```bash
+php artisan storage:unlink
+```
+
+Source: https://artisan.page/11.x/storageunlink.md
+
+### `php artisan stub:publish`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan stub:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/11.x/stubpublish.md
+
+### `php artisan telescope:clear`
+
+Delete all Telescope data from storage
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/11.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/11.x/telescopeinstall.md
+
+### `php artisan telescope:pause`
+
+Pause all Telescope watchers
+
+```bash
+php artisan telescope:pause
+```
+
+Source: https://artisan.page/11.x/telescopepause.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]] [--keep-exceptions]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data; default: `24`
+- `--keep-exceptions` — Retain exception data
+
+Source: https://artisan.page/11.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/11.x/telescopepublish.md
+
+### `php artisan telescope:resume`
+
+Unpause all Telescope watchers
+
+```bash
+php artisan telescope:resume
+```
+
+Source: https://artisan.page/11.x/telescoperesume.md
+
+### `php artisan test`
+
+Run the application tests
+
+```bash
+php artisan test [--without-tty] [--compact] [--coverage] [--min [MIN]] [-p|--parallel] [--profile] [--recreate-databases] [--drop-databases] [--without-databases] [--without-cache]
+```
+
+Options:
+- `--compact` — Indicates whether the compact printer should be used
+- `--coverage` — Indicates whether code coverage information should be collected
+- `--drop-databases` — Indicates if the test databases should be dropped
+- `--min` (value optional) — Indicates the minimum threshold enforcement for code coverage
+- `--parallel` — Indicates if the tests should run in parallel
+- `--profile` — Lists top 10 slowest tests
+- `--recreate-databases` — Indicates if the test databases should be re-created
+- `--without-cache` — Indicates if cache configuration should be performed
+- `--without-databases` — Indicates if database configuration should be performed
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/11.x/test.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/11.x/tinker.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/11.x/up.md
+
+### `php artisan vapor:handle`
+
+```bash
+php artisan vapor:handle <payload>
+```
+
+Arguments:
+- `payload` (required)
+
+Source: https://artisan.page/11.x/vaporhandle.md
+
+### `php artisan vapor:health-check`
+
+Check the health of the Vapor application
+
+```bash
+php artisan vapor:health-check
+```
+
+Source: https://artisan.page/11.x/vaporhealth-check.md
+
+### `php artisan vapor:queue-failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan vapor:queue-failed [--limit [LIMIT]] [--page [PAGE]] [--id [ID]] [--queue [QUEUE]] [--query [QUERY]] [--start [START]]
+```
+
+Options:
+- `--id` (value optional) — The job ID filter by
+- `--limit` (value optional) — The number of failed jobs to return
+- `--page` (value optional) — The page of failed jobs to return; default: `1`
+- `--query` (value optional) — The search query to filter by
+- `--queue` (value optional) — The queue to filter by
+- `--start` (value optional) — The start timestamp to filter by
+
+Source: https://artisan.page/11.x/vaporqueue-failed.md
+
+### `php artisan vapor:schedule`
+
+Run the scheduled commands at the beginning of every minute
+
+```bash
+php artisan vapor:schedule
+```
+
+Source: https://artisan.page/11.x/vaporschedule.md
+
+### `php artisan vapor:work`
+
+Process a Vapor job
+
+```bash
+php artisan vapor:work [--delay [DELAY]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--force]
+```
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `0`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/11.x/vaporwork.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--existing] [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/11.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/11.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/11.x/viewclear.md
+
+### `php artisan volt:install`
+
+Install all of the Volt resources
+
+```bash
+php artisan volt:install
+```
+
+Source: https://artisan.page/11.x/voltinstall.md
+
+## Laravel 10.x
+
+227 documented commands.
+
+### `php artisan _complete`
+
+Internal command to provide shell completion suggestions
+
+```bash
+php artisan _complete [-s|--shell SHELL] [-i|--input INPUT] [-c|--current CURRENT] [-a|--api-version API-VERSION] [-S|--symfony SYMFONY]
+```
+
+Options:
+- `--api-version` (value required) — The API version of the completion script
+- `--current` (value required) — The index of the "input" array that the cursor is in (e.g. COMP_CWORD)
+- `--input` (value required) — An array of input tokens (e.g. COMP_WORDS or argv)
+- `--shell` (value required) — The shell type ("bash", "fish", "zsh")
+- `--symfony` (value required) — deprecated
+
+Source: https://artisan.page/10.x/_complete.md
+
+### `php artisan about`
+
+Display basic information about your application
+
+```bash
+php artisan about [--only [ONLY]] [--json]
+```
+
+Options:
+- `--json` — Output the information as JSON
+- `--only` (value optional) — The section to display
+
+Source: https://artisan.page/10.x/about.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/10.x/authclear-resets.md
+
+### `php artisan breeze:install`
+
+Install the Breeze controllers and resources
+
+```bash
+php artisan breeze:install [--dark] [--pest] [--ssr] [--typescript] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (blade,livewire,livewire-functional,react,vue,api)
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--pest` — Indicate that Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--typescript` — Indicates if TypeScript is preferred for the Inertia stack (Experimental)
+
+Source: https://artisan.page/10.x/breezeinstall.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/10.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/10.x/cacheforget.md
+
+### `php artisan cache:prune-stale-tags`
+
+Prune stale cache tags from the cache (Redis only)
+
+```bash
+php artisan cache:prune-stale-tags [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to prune tags from
+
+Source: https://artisan.page/10.x/cacheprune-stale-tags.md
+
+### `php artisan cache:table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan cache:table
+```
+
+Source: https://artisan.page/10.x/cachetable.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/10.x/cashierwebhook.md
+
+### `php artisan channel:list`
+
+List all registered private broadcast channels
+
+```bash
+php artisan channel:list
+```
+
+Source: https://artisan.page/10.x/channellist.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/10.x/clear-compiled.md
+
+### `php artisan completion`
+
+Dump the shell completion script
+
+```bash
+php artisan completion [--debug] [--] [<shell>]
+```
+
+Arguments:
+- `shell` — The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+Options:
+- `--debug` — Tail the completion debug log
+
+Source: https://artisan.page/10.x/completion.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/10.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/10.x/configclear.md
+
+### `php artisan config:show`
+
+Display all of the values for a given configuration file
+
+```bash
+php artisan config:show <config>
+```
+
+Arguments:
+- `config` (required) — The configuration file to show
+
+Source: https://artisan.page/10.x/configshow.md
+
+### `php artisan db`
+
+Start a new database CLI session
+
+```bash
+php artisan db [--read] [--write] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The database connection that should be used
+
+Options:
+- `--read` — Connect to the read connection
+- `--write` — Connect to the write connection
+
+Source: https://artisan.page/10.x/db.md
+
+### `php artisan db:monitor`
+
+Monitor the number of connections on the specified database
+
+```bash
+php artisan db:monitor [--databases [DATABASES]] [--max [MAX]]
+```
+
+Options:
+- `--databases` (value optional) — The database connections to monitor
+- `--max` (value optional) — The maximum number of connections that can be open before an event is dispatched
+
+Source: https://artisan.page/10.x/dbmonitor.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force] [--] [<class>]
+```
+
+Arguments:
+- `class` — The class name of the root seeder
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `Database\Seeders\DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/10.x/dbseed.md
+
+### `php artisan db:show`
+
+Display information about the given database
+
+```bash
+php artisan db:show [--database [DATABASE]] [--json] [--counts] [--views]
+```
+
+Options:
+- `--counts` — Show the table row count <bg=red;options=bold> Note: This can be slow on large databases </>
+- `--database` (value optional) — The database connection
+- `--json` — Output the database information as JSON
+- `--views` — Show the database views <bg=red;options=bold> Note: This can be slow on large databases </>
+
+Source: https://artisan.page/10.x/dbshow.md
+
+### `php artisan db:table`
+
+Display information about the given database table
+
+```bash
+php artisan db:table [--database [DATABASE]] [--json] [--] [<table>]
+```
+
+Arguments:
+- `table` — The name of the table
+
+Options:
+- `--database` (value optional) — The database connection
+- `--json` — Output the table information as JSON
+
+Source: https://artisan.page/10.x/dbtable.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/10.x/dbwipe.md
+
+### `php artisan docs`
+
+Access the Laravel documentation
+
+```bash
+php artisan docs [<page> [<section>]]
+```
+
+Arguments:
+- `page` — The documentation page to open
+- `section` — The section of the page to open
+
+Source: https://artisan.page/10.x/docs.md
+
+### `php artisan down`
+
+Put the application into maintenance / demo mode
+
+```bash
+php artisan down [--redirect [REDIRECT]] [--render [RENDER]] [--retry [RETRY]] [--refresh [REFRESH]] [--secret [SECRET]] [--with-secret] [--status [STATUS]]
+```
+
+Options:
+- `--redirect` (value optional) — The path that users should be redirected to
+- `--refresh` (value optional) — The number of seconds after which the browser may refresh
+- `--render` (value optional) — The view that should be prerendered for display during maintenance mode
+- `--retry` (value optional) — The number of seconds after which the request may be retried
+- `--secret` (value optional) — The secret phrase that may be used to bypass maintenance mode
+- `--status` (value optional) — The status code that should be used when returning the maintenance mode response; default: `503`
+- `--with-secret` — Generate a random secret phrase that may be used to bypass maintenance mode
+
+Source: https://artisan.page/10.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/10.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/10.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/10.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/10.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/10.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/10.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/10.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/10.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/10.x/env.md
+
+### `php artisan env:decrypt`
+
+Decrypt an environment file
+
+```bash
+php artisan env:decrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--force] [--path [PATH]] [--filename [FILENAME]]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be decrypted
+- `--filename` (value optional) — Filename of the decrypted file
+- `--force` — Overwrite the existing environment file
+- `--key` (value optional) — The encryption key
+- `--path` (value optional) — Path to write the decrypted file
+
+Source: https://artisan.page/10.x/envdecrypt.md
+
+### `php artisan env:encrypt`
+
+Encrypt an environment file
+
+```bash
+php artisan env:encrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--force]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be encrypted
+- `--force` — Overwrite the existing encrypted environment file
+- `--key` (value optional) — The encryption key
+
+Source: https://artisan.page/10.x/envencrypt.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/10.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/10.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/10.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+
+Source: https://artisan.page/10.x/eventlist.md
+
+### `php artisan fortify:install`
+
+Install all of the Fortify resources
+
+```bash
+php artisan fortify:install
+```
+
+Source: https://artisan.page/10.x/fortifyinstall.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/10.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/10.x/horizon.md
+
+### `php artisan horizon:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan horizon:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/10.x/horizonclear.md
+
+### `php artisan horizon:clear-metrics`
+
+Delete metrics for all jobs and queues
+
+```bash
+php artisan horizon:clear-metrics
+```
+
+Source: https://artisan.page/10.x/horizonclear-metrics.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/10.x/horizoncontinue.md
+
+### `php artisan horizon:continue-supervisor`
+
+Instruct the supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to resume
+
+Source: https://artisan.page/10.x/horizoncontinue-supervisor.md
+
+### `php artisan horizon:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan horizon:forget [--all] [--] [<id>]
+```
+
+Arguments:
+- `id` — The ID of the failed job
+
+Options:
+- `--all` — Delete all failed jobs
+
+Source: https://artisan.page/10.x/horizonforget.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/10.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/10.x/horizonlist.md
+
+### `php artisan horizon:listen`
+
+Run Horizon and automatically restart workers on file changes
+
+```bash
+php artisan horizon:listen [--environment [ENVIRONMENT]] [--poll]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+- `--poll` — Use polling for file watching
+
+Source: https://artisan.page/10.x/horizonlisten.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/10.x/horizonpause.md
+
+### `php artisan horizon:pause-supervisor`
+
+Pause a supervisor
+
+```bash
+php artisan horizon:pause-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to pause
+
+Source: https://artisan.page/10.x/horizonpause-supervisor.md
+
+### `php artisan horizon:publish`
+
+Publish all of the Horizon resources
+
+```bash
+php artisan horizon:publish
+```
+
+Source: https://artisan.page/10.x/horizonpublish.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge [--signal [SIGNAL]]
+```
+
+Options:
+- `--signal` (value optional) — The signal to send to the rogue processes; default: `SIGTERM`
+
+Source: https://artisan.page/10.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/10.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/10.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--auto-scaling-strategy [AUTO-SCALING-STRATEGY]] [--balance-cooldown [BALANCE-COOLDOWN]] [--balance-max-shift [BALANCE-MAX-SHIFT]] [--workers-name [WORKERS-NAME]] [--parent-id [PARENT-ID]] [--rest [REST]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--auto-scaling-strategy` (value optional) — If supervisor should scale by jobs or time to complete; default: `time`
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--balance-cooldown` (value optional) — The number of seconds to wait in between auto-scaling attempts; default: `3`
+- `--balance-max-shift` (value optional) — The maximum number of processes to increase or decrease per one scaling; default: `1`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping a child process; default: `0`
+- `--max-processes` (value optional) — The maximum number of total workers to start; default: `1`
+- `--max-time` (value optional) — The maximum number of seconds a child process should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue; default: `1`
+- `--nice` (value optional) — The process priority; default: `0`
+- `--parent-id` (value optional) — The parent process ID; default: `0`
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+- `--workers-name` (value optional) — The name that should be assigned to the workers; default: `default`
+
+Source: https://artisan.page/10.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisor-status`
+
+Show the status for a given supervisor
+
+```bash
+php artisan horizon:supervisor-status <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor
+
+Source: https://artisan.page/10.x/horizonsupervisor-status.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/10.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/10.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/10.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--stop-when-empty-for [STOP-WHEN-EMPTY-FOR]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--json] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--json` — Output the queue worker information as JSON
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--stop-when-empty-for` (value optional) — Stop when no jobs have been processed for the given number of seconds; default: `0`
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/10.x/horizonwork.md
+
+### `php artisan inertia:check-ssr`
+
+Check the Inertia SSR server health status
+
+```bash
+php artisan inertia:check-ssr
+```
+
+Source: https://artisan.page/10.x/inertiacheck-ssr.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/10.x/inertiamiddleware.md
+
+### `php artisan inertia:start-ssr`
+
+Start the Inertia SSR server
+
+```bash
+php artisan inertia:start-ssr [--runtime [RUNTIME]]
+```
+
+Options:
+- `--runtime` (value optional) — The runtime to use (`node` or `bun`); default: `node`
+
+Source: https://artisan.page/10.x/inertiastart-ssr.md
+
+### `php artisan inertia:stop-ssr`
+
+Stop the Inertia SSR server
+
+```bash
+php artisan inertia:stop-ssr
+```
+
+Source: https://artisan.page/10.x/inertiastop-ssr.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/10.x/inspire.md
+
+### `php artisan jetstream:install`
+
+Install the Jetstream components and resources
+
+```bash
+php artisan jetstream:install [--dark] [--teams] [--api] [--verification] [--pest] [--ssr] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (inertia,livewire)
+
+Options:
+- `--api` — Indicates if API support should be installed
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--dark` — Indicate that dark mode support should be installed
+- `--pest` — Indicates if Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--teams` — Indicates if team support should be installed
+- `--verification` — Indicates if email verification support should be installed
+
+Source: https://artisan.page/10.x/jetstreaminstall.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/10.x/keygenerate.md
+
+### `php artisan lang:publish`
+
+Publish all language files that are available for customization
+
+```bash
+php artisan lang:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/10.x/langpublish.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--short] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+- `--short` — To skip describing commands' arguments
+
+Source: https://artisan.page/10.x/list.md
+
+### `php artisan livewire:attribute`
+
+Create a new Livewire attribute class
+
+```bash
+php artisan livewire:attribute [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/10.x/livewireattribute.md
+
+### `php artisan livewire:config`
+
+Publish Livewire config file
+
+```bash
+php artisan livewire:config
+```
+
+Source: https://artisan.page/10.x/livewireconfig.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/10.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:convert`
+
+Convert a Livewire component between single-file and multi-file formats
+
+```bash
+php artisan livewire:convert [--sfc] [--mfc] [--test] [--emoji EMOJI] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--mfc` — Convert to multi-file component
+- `--sfc` — Convert to single-file component
+- `--test` — Create a test file when converting to multi-file (if one does not exist)
+
+Source: https://artisan.page/10.x/livewireconvert.md
+
+### `php artisan livewire:form`
+
+Create a new Livewire form class
+
+```bash
+php artisan livewire:form [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+
+Source: https://artisan.page/10.x/livewireform.md
+
+### `php artisan livewire:layout`
+
+Create a new app layout file
+
+```bash
+php artisan livewire:layout [--force] [--stub [STUB]]
+```
+
+Options:
+- `--force`
+- `--stub` (value optional) — If you have several stubs, stored in subfolders
+
+Source: https://artisan.page/10.x/livewirelayout.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/10.x/livewiremake.md
+
+### `php artisan livewire:publish`
+
+Publish Livewire configuration
+
+```bash
+php artisan livewire:publish [--assets] [--config] [--pagination]
+```
+
+Options:
+- `--assets` — Indicates if Livewire's front-end assets should be published
+- `--config` — Indicates if Livewire's config file should be published
+- `--pagination` — Indicates if Livewire's pagination views should be published
+
+Source: https://artisan.page/10.x/livewirepublish.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/10.x/livewirestubs.md
+
+### `php artisan make:cast`
+
+Create a new custom Eloquent cast class
+
+```bash
+php artisan make:cast [-f|--force] [--inbound] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the cast
+
+Options:
+- `--force` — Create the class even if the cast already exists
+- `--inbound` — Generate an inbound cast class
+
+Source: https://artisan.page/10.x/makecast.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the channel
+
+Options:
+- `--force` — Create the class even if the channel already exists
+
+Source: https://artisan.page/10.x/makechannel.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [-f|--force] [--command [COMMAND]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that will be used to invoke the class
+- `--force` — Create the class even if the console command already exists
+- `--pest` — Generate an accompanying Pest test for the Console command
+- `--test` — Generate an accompanying PHPUnit test for the Console command
+
+Source: https://artisan.page/10.x/makecommand.md
+
+### `php artisan make:component`
+
+Create a new view component class
+
+```bash
+php artisan make:component [-f|--force] [--inline] [--view] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--force` — Create the class even if the component already exists
+- `--inline` — Create a component that renders an inline view
+- `--pest` — Generate an accompanying Pest test for the Component
+- `--test` — Generate an accompanying PHPUnit test for the Component
+- `--view` — Create an anonymous component with only a view
+
+Source: https://artisan.page/10.x/makecomponent.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--type TYPE] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [-R|--requests] [-s|--singleton] [--creatable] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the controller
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller
+- `--creatable` — Indicate that a singleton resource should be creatable
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class
+- `--model` (value optional) — Generate a resource controller for the given model
+- `--parent` (value optional) — Generate a nested resource controller class
+- `--pest` — Generate an accompanying Pest test for the Controller
+- `--requests` — Generate FormRequest classes for store and update
+- `--resource` — Generate a resource controller class
+- `--singleton` — Generate a singleton resource controller class
+- `--test` — Generate an accompanying PHPUnit test for the Controller
+- `--type` (value required) — Manually specify the controller stub file to use
+
+Source: https://artisan.page/10.x/makecontroller.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the event
+
+Options:
+- `--force` — Create the class even if the event already exists
+
+Source: https://artisan.page/10.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [-f|--force] [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the exception
+
+Options:
+- `--force` — Create the class even if the exception already exists
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/10.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the factory
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/10.x/makefactory.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [-f|--force] [--sync] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the job
+
+Options:
+- `--force` — Create the class even if the job already exists
+- `--pest` — Generate an accompanying Pest test for the Job
+- `--sync` — Indicates that job should be synchronous
+- `--test` — Generate an accompanying PHPUnit test for the Job
+
+Source: https://artisan.page/10.x/makejob.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [-f|--force] [--queued] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the listener
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--force` — Create the class even if the listener already exists
+- `--pest` — Generate an accompanying Pest test for the Listener
+- `--queued` — Indicates the event listener should be queued
+- `--test` — Generate an accompanying PHPUnit test for the Listener
+
+Source: https://artisan.page/10.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--sfc] [--mfc] [--class] [--type TYPE] [--test] [--emoji EMOJI] [--js] [--css] [--] [<name>]
+```
+
+Arguments:
+- `name` — The name of the component
+
+Options:
+- `--class` — Create a class-based component
+- `--css` — Create CSS files for multi-file components
+- `--emoji` (value required) — Use emoji in file/directory names (true or false)
+- `--js` — Create a JavaScript file for multi-file components
+- `--mfc` — Create a multi-file component
+- `--sfc` — Create a single-file component
+- `--test` — Create a test file
+- `--type` (value required) — Component type (sfc, mfc, or class)
+
+Source: https://artisan.page/10.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the mailable
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+- `--pest` — Generate an accompanying Pest test for the Mailable
+- `--test` — Generate an accompanying PHPUnit test for the Mailable
+
+Source: https://artisan.page/10.x/makemail.md
+
+### `php artisan make:middleware`
+
+Create a new middleware class
+
+```bash
+php artisan make:middleware [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--test` — Generate an accompanying PHPUnit test for the Middleware
+
+Source: https://artisan.page/10.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration (Deprecated)
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/10.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [--morph-pivot] [--policy] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [-R|--requests] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the model
+
+Options:
+- `--all` — Generate a migration, seeder, factory, policy, resource controller, and form request classes for the model
+- `--api` — Indicates if the generated controller should be an API resource controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--morph-pivot` — Indicates if the generated model should be a custom polymorphic intermediate table model
+- `--pest` — Generate an accompanying Pest test for the Model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--policy` — Create a new policy for the model
+- `--requests` — Create new form request classes and use them in the resource controller
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder for the model
+- `--test` — Generate an accompanying PHPUnit test for the Model
+
+Source: https://artisan.page/10.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the notification
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+- `--pest` — Generate an accompanying Pest test for the Notification
+- `--test` — Generate an accompanying PHPUnit test for the Notification
+
+Source: https://artisan.page/10.x/makenotification.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-f|--force] [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the observer
+
+Options:
+- `--force` — Create the class even if the observer already exists
+- `--model` (value optional) — The model that the observer applies to
+
+Source: https://artisan.page/10.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-f|--force] [-m|--model [MODEL]] [-g|--guard [GUARD]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--guard` (value optional) — The guard that the policy relies on
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/10.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the provider
+
+Options:
+- `--force` — Create the class even if the provider already exists
+
+Source: https://artisan.page/10.x/makeprovider.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the request
+
+Options:
+- `--force` — Create the class even if the request already exists
+
+Source: https://artisan.page/10.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-f|--force] [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--collection` — Create a resource collection
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/10.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule [-f|--force] [-i|--implicit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the rule
+
+Options:
+- `--force` — Create the class even if the rule already exists
+- `--implicit` — Generate an implicit rule
+
+Source: https://artisan.page/10.x/makerule.md
+
+### `php artisan make:scope`
+
+Create a new scope class
+
+```bash
+php artisan make:scope [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the scope
+
+Options:
+- `--force` — Create the class even if the scope already exists
+
+Source: https://artisan.page/10.x/makescope.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the seeder
+
+Source: https://artisan.page/10.x/makeseeder.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [-f|--force] [-u|--unit] [-p|--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the test
+
+Options:
+- `--force` — Create the class even if the test already exists
+- `--pest` — Create a Pest test
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/10.x/maketest.md
+
+### `php artisan make:view`
+
+Create a new view
+
+```bash
+php artisan make:view [--extension [EXTENSION]] [-f|--force] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the view
+
+Options:
+- `--extension` (value optional) — The extension of the generated view; default: `blade.php`
+- `--force` — Create the view even if the view already exists
+- `--pest` — Generate an accompanying Pest test for the View
+- `--test` — Generate an accompanying PHPUnit test for the View
+
+Source: https://artisan.page/10.x/makeview.md
+
+### `php artisan make:volt`
+
+Create a new Volt component
+
+```bash
+php artisan make:volt [--class] [--functional] [-f|--force] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the volt component
+
+Options:
+- `--class` — Create a class based component
+- `--force` — Create the Volt component even if the component already exists
+- `--functional` — Create a functional component
+- `--pest` — Generate an accompanying Pest test for the Volt component
+- `--test` — Generate an accompanying PHPUnit test for the Volt component
+
+Source: https://artisan.page/10.x/makevolt.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--pretend] [--seed] [--seeder [SEEDER]] [--step] [--isolated [ISOLATED]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/10.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/10.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/10.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/10.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/10.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]] [--batch BATCH]
+```
+
+Options:
+- `--batch` (value required) — The batch of migrations (identified by their batch number) to be reverted
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/10.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--pending] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--pending` — Only list pending migrations
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/10.x/migratestatus.md
+
+### `php artisan model:prune`
+
+Prune models that are no longer needed
+
+```bash
+php artisan model:prune [--model [MODEL]] [--except [EXCEPT]] [--path [PATH]] [--chunk [CHUNK]] [--pretend]
+```
+
+Options:
+- `--chunk` (value optional) — The number of models to retrieve per chunk of models to be deleted; default: `1000`
+- `--except` (value optional) — Class names of the models to be excluded from pruning
+- `--model` (value optional) — Class names of the models to be pruned
+- `--path` (value optional) — Absolute path(s) to directories where models are located
+- `--pretend` — Display the number of prunable records found instead of deleting them
+
+Source: https://artisan.page/10.x/modelprune.md
+
+### `php artisan model:show`
+
+Show information about an Eloquent model
+
+```bash
+php artisan model:show [--database [DATABASE]] [--json] [--] <model>
+```
+
+Arguments:
+- `model` (required) — The model to show
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--json` — Output the model as JSON
+
+Source: https://artisan.page/10.x/modelshow.md
+
+### `php artisan notifications:table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan notifications:table
+```
+
+Source: https://artisan.page/10.x/notificationstable.md
+
+### `php artisan nova:action`
+
+Create a new action class
+
+```bash
+php artisan nova:action [--destructive] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the action
+
+Options:
+- `--destructive` — Indicate that the action deletes / destroys resources
+- `--queued` — Indicates the action should be queued
+
+Source: https://artisan.page/10.x/novaaction.md
+
+### `php artisan nova:asset`
+
+Create a new asset
+
+```bash
+php artisan nova:asset <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/10.x/novaasset.md
+
+### `php artisan nova:base-resource`
+
+Create a new base resource class
+
+```bash
+php artisan nova:base-resource <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Source: https://artisan.page/10.x/novabase-resource.md
+
+### `php artisan nova:card`
+
+Create a new card
+
+```bash
+php artisan nova:card <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/10.x/novacard.md
+
+### `php artisan nova:check-license`
+
+Verify your Nova license key
+
+```bash
+php artisan nova:check-license
+```
+
+Source: https://artisan.page/10.x/novacheck-license.md
+
+### `php artisan nova:custom-filter`
+
+Create a new custom filter
+
+```bash
+php artisan nova:custom-filter <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/10.x/novacustom-filter.md
+
+### `php artisan nova:dashboard`
+
+Create a new dashboard.
+
+```bash
+php artisan nova:dashboard <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/10.x/novadashboard.md
+
+### `php artisan nova:field`
+
+Create a new field
+
+```bash
+php artisan nova:field <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/10.x/novafield.md
+
+### `php artisan nova:filter`
+
+Create a new filter class
+
+```bash
+php artisan nova:filter [--boolean] [--date] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the filter
+
+Options:
+- `--boolean` — Indicates if the generated filter should be a boolean filter
+- `--date` — Indicates if the generated filter should be a date filter
+
+Source: https://artisan.page/10.x/novafilter.md
+
+### `php artisan nova:install`
+
+Install all of the Nova resources
+
+```bash
+php artisan nova:install
+```
+
+Source: https://artisan.page/10.x/novainstall.md
+
+### `php artisan nova:lens`
+
+Create a new lens class
+
+```bash
+php artisan nova:lens <name>
+```
+
+Arguments:
+- `name` (required) — The name of the lens
+
+Source: https://artisan.page/10.x/novalens.md
+
+### `php artisan nova:partition`
+
+Create a new metric (partition) class
+
+```bash
+php artisan nova:partition <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/10.x/novapartition.md
+
+### `php artisan nova:policy`
+
+Create a new policy class
+
+```bash
+php artisan nova:policy [-f|--force] [-m|--resource [RESOURCE]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--resource` (value optional) — The resource that the policy applies to
+
+Source: https://artisan.page/10.x/novapolicy.md
+
+### `php artisan nova:progress`
+
+Create a new metric (progress) class
+
+```bash
+php artisan nova:progress <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/10.x/novaprogress.md
+
+### `php artisan nova:publish`
+
+Publish all of the Nova resources
+
+```bash
+php artisan nova:publish [-f|--force] [--fortify|--no-fortify]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+- `--fortify` — Publish Laravel Fortify features
+
+Source: https://artisan.page/10.x/novapublish.md
+
+### `php artisan nova:repeatable`
+
+Create a new repeatable class
+
+```bash
+php artisan nova:repeatable [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the repeatable
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/10.x/novarepeatable.md
+
+### `php artisan nova:resource`
+
+Create a new resource class
+
+```bash
+php artisan nova:resource [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/10.x/novaresource.md
+
+### `php artisan nova:resource-tool`
+
+Create a new resource tool
+
+```bash
+php artisan nova:resource-tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/10.x/novaresource-tool.md
+
+### `php artisan nova:stubs`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan nova:stubs [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/10.x/novastubs.md
+
+### `php artisan nova:table`
+
+Create a new metric (table) class
+
+```bash
+php artisan nova:table <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/10.x/novatable.md
+
+### `php artisan nova:tool`
+
+Create a new tool
+
+```bash
+php artisan nova:tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/10.x/novatool.md
+
+### `php artisan nova:translate`
+
+Create translation files for Nova
+
+```bash
+php artisan nova:translate [--force] [--] <language>
+```
+
+Arguments:
+- `language` (required)
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/10.x/novatranslate.md
+
+### `php artisan nova:trend`
+
+Create a new metric (trend) class
+
+```bash
+php artisan nova:trend <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/10.x/novatrend.md
+
+### `php artisan nova:user`
+
+Create a new user
+
+```bash
+php artisan nova:user
+```
+
+Source: https://artisan.page/10.x/novauser.md
+
+### `php artisan nova:value`
+
+Create a new metric (single value) class
+
+```bash
+php artisan nova:value <name>
+```
+
+Arguments:
+- `name` (required) — The name of the metric
+
+Source: https://artisan.page/10.x/novavalue.md
+
+### `php artisan octane:frankenphp`
+
+Start the Octane FrankenPHP server
+
+```bash
+php artisan octane:frankenphp [--host [HOST]] [--port [PORT]] [--admin-host [ADMIN-HOST]] [--admin-port [ADMIN-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-host` (value optional) — The host the admin server should be available on; default: `localhost`
+- `--admin-port` (value optional) — The port the admin server should be available on; default: `2019`
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to; default: `127.0.0.1`
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed)
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/10.x/octanefrankenphp.md
+
+### `php artisan octane:install`
+
+Install the Octane components and resources
+
+```bash
+php artisan octane:install [--server [SERVER]] [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing configuration files
+- `--server` (value optional) — The server that should be used to serve the application
+
+Source: https://artisan.page/10.x/octaneinstall.md
+
+### `php artisan octane:reload`
+
+Reload the Octane workers
+
+```bash
+php artisan octane:reload [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/10.x/octanereload.md
+
+### `php artisan octane:roadrunner`
+
+Start the Octane RoadRunner server
+
+```bash
+php artisan octane:roadrunner [--host [HOST]] [--port [PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/10.x/octaneroadrunner.md
+
+### `php artisan octane:start`
+
+Start the Octane server
+
+```bash
+php artisan octane:start [--server [SERVER]] [--host [HOST]] [--port [PORT]] [--admin-port [ADMIN-PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--caddyfile [CADDYFILE]] [--https] [--http-redirect] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--admin-port` (value optional) — The port the admin server should be available on [FrankenPHP only]
+- `--caddyfile` (value optional) — The path to the FrankenPHP Caddyfile file
+- `--host` (value optional) — The IP address the server should bind to
+- `--http-redirect` — Enable HTTP to HTTPS redirection (only enabled if --https is passed) [FrankenPHP only]
+- `--https` — Enable HTTPS, HTTP/2, and HTTP/3, and automatically generate and renew certificates [FrankenPHP only]
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on [default: "8000"]
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--server` (value optional) — The server that should be used to serve the application
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests
+
+Source: https://artisan.page/10.x/octanestart.md
+
+### `php artisan octane:status`
+
+Get the current status of the Octane server
+
+```bash
+php artisan octane:status [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/10.x/octanestatus.md
+
+### `php artisan octane:stop`
+
+Stop the Octane server
+
+```bash
+php artisan octane:stop [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/10.x/octanestop.md
+
+### `php artisan octane:swoole`
+
+Start the Octane Swoole server
+
+```bash
+php artisan octane:swoole [--host [HOST]] [--port [PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--watch] [--poll]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks; default: `auto`
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/10.x/octaneswoole.md
+
+### `php artisan optimize`
+
+Cache the framework bootstrap files
+
+```bash
+php artisan optimize
+```
+
+Source: https://artisan.page/10.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear
+```
+
+Source: https://artisan.page/10.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/10.x/packagediscover.md
+
+### `php artisan passport:client`
+
+Create a client for issuing access tokens
+
+```bash
+php artisan passport:client [--personal] [--password] [--client] [--name [NAME]] [--provider [PROVIDER]] [--redirect_uri [REDIRECT_URI]] [--user_id [USER_ID]] [--public]
+```
+
+Options:
+- `--client` — Create a client credentials grant client
+- `--name` (value optional) — The name of the client
+- `--password` — Create a password grant client
+- `--personal` — Create a personal access token client
+- `--provider` (value optional) — The name of the user provider
+- `--public` — Create a public client (Auth code grant type only)
+- `--redirect_uri` (value optional) — The URI to redirect to after authorization
+- `--user_id` (value optional) — The user ID the client should be assigned to
+
+Source: https://artisan.page/10.x/passportclient.md
+
+### `php artisan passport:hash`
+
+Hash all of the existing secrets in the clients table
+
+```bash
+php artisan passport:hash [--force]
+```
+
+Options:
+- `--force` — Force the operation to run without confirmation prompt
+
+Source: https://artisan.page/10.x/passporthash.md
+
+### `php artisan passport:install`
+
+Run the commands necessary to prepare Passport for use
+
+```bash
+php artisan passport:install [--uuids] [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+- `--uuids` — Use UUIDs for all client IDs
+
+Source: https://artisan.page/10.x/passportinstall.md
+
+### `php artisan passport:keys`
+
+Create the encryption keys for API authentication
+
+```bash
+php artisan passport:keys [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/10.x/passportkeys.md
+
+### `php artisan passport:purge`
+
+Purge revoked and / or expired tokens and authentication codes
+
+```bash
+php artisan passport:purge [--revoked] [--expired] [--hours [HOURS]]
+```
+
+Options:
+- `--expired` — Only purge expired tokens and authentication codes
+- `--hours` (value optional) — The number of hours to retain expired tokens; default: `168`
+- `--revoked` — Only purge revoked tokens and authentication codes
+
+Source: https://artisan.page/10.x/passportpurge.md
+
+### `php artisan pennant:feature`
+
+Create a new feature class
+
+```bash
+php artisan pennant:feature [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the feature
+
+Options:
+- `--force` — Create the class even if the feature already exists
+
+Source: https://artisan.page/10.x/pennantfeature.md
+
+### `php artisan pennant:purge`
+
+Delete Pennant features from storage
+
+```bash
+php artisan pennant:purge [--except [EXCEPT]] [--except-registered] [--store [STORE]] [--] [<features>...]
+```
+
+Arguments:
+- `features` — The features to purge
+
+Options:
+- `--except` (value optional) — The features that should be excluded from purging
+- `--except-registered` — Purge all features except those registered
+- `--store` (value optional) — The store to purge the features from
+
+Aliases: `pennant:clear`
+
+Source: https://artisan.page/10.x/pennantpurge.md
+
+### `php artisan pulse:check`
+
+Take a snapshot of the current server's pulse
+
+```bash
+php artisan pulse:check [--once]
+```
+
+Options:
+- `--once` — Take a single snapshot
+
+Source: https://artisan.page/10.x/pulsecheck.md
+
+### `php artisan pulse:clear`
+
+Delete all Pulse data from storage
+
+```bash
+php artisan pulse:clear [--type [TYPE]] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--type` (value optional) — Only clear the specified type(s)
+
+Aliases: `pulse:purge`
+
+Source: https://artisan.page/10.x/pulseclear.md
+
+### `php artisan pulse:restart`
+
+Restart any running "work" and "check" commands
+
+```bash
+php artisan pulse:restart
+```
+
+Source: https://artisan.page/10.x/pulserestart.md
+
+### `php artisan pulse:work`
+
+Process incoming Pulse data from the ingest stream
+
+```bash
+php artisan pulse:work [--stop-when-empty]
+```
+
+Options:
+- `--stop-when-empty` — Stop when the stream is empty
+
+Source: https://artisan.page/10.x/pulsework.md
+
+### `php artisan queue:batches-table`
+
+Create a migration for the batches database table
+
+```bash
+php artisan queue:batches-table
+```
+
+Source: https://artisan.page/10.x/queuebatches-table.md
+
+### `php artisan queue:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan queue:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to clear
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/10.x/queueclear.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/10.x/queuefailed.md
+
+### `php artisan queue:failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan queue:failed-table
+```
+
+Source: https://artisan.page/10.x/queuefailed-table.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed job data
+
+Source: https://artisan.page/10.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/10.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--queue` (value optional) — The queue to listen on
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/10.x/queuelisten.md
+
+### `php artisan queue:monitor`
+
+Monitor the size of the specified queues
+
+```bash
+php artisan queue:monitor [--max [MAX]] [--] <queues>
+```
+
+Arguments:
+- `queues` (required) — The names of the queues to monitor
+
+Options:
+- `--max` (value optional) — The maximum number of jobs that can be on the queue before an event is dispatched; default: `1000`
+
+Source: https://artisan.page/10.x/queuemonitor.md
+
+### `php artisan queue:prune-batches`
+
+Prune stale entries from the batches database
+
+```bash
+php artisan queue:prune-batches [--hours [HOURS]] [--unfinished [UNFINISHED]] [--cancelled [CANCELLED]]
+```
+
+Options:
+- `--cancelled` (value optional) — The number of hours to retain cancelled batch data
+- `--hours` (value optional) — The number of hours to retain batch data; default: `24`
+- `--unfinished` (value optional) — The number of hours to retain unfinished batch data
+
+Source: https://artisan.page/10.x/queueprune-batches.md
+
+### `php artisan queue:prune-failed`
+
+Prune stale entries from the failed jobs table
+
+```bash
+php artisan queue:prune-failed [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed jobs data; default: `24`
+
+Source: https://artisan.page/10.x/queueprune-failed.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/10.x/queuerestart.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry [--queue [QUEUE]] [--range [RANGE]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the failed job or "all" to retry all jobs
+
+Options:
+- `--queue` (value optional) — Retry all of the failed jobs for the specified queue
+- `--range` (value optional) — Range of job IDs (numeric) to be retried (e.g. 1-5)
+
+Source: https://artisan.page/10.x/queueretry.md
+
+### `php artisan queue:retry-batch`
+
+Retry the failed jobs for a batch
+
+```bash
+php artisan queue:retry-batch [--isolated [ISOLATED]] [--] <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the batch whose failed jobs should be retried
+
+Options:
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+
+Source: https://artisan.page/10.x/queueretry-batch.md
+
+### `php artisan queue:table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan queue:table
+```
+
+Source: https://artisan.page/10.x/queuetable.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--name [NAME]] [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/10.x/queuework.md
+
+### `php artisan reverb:install`
+
+Install the Reverb dependencies
+
+```bash
+php artisan reverb:install
+```
+
+Source: https://artisan.page/10.x/reverbinstall.md
+
+### `php artisan reverb:restart`
+
+Restart the Reverb server
+
+```bash
+php artisan reverb:restart
+```
+
+Source: https://artisan.page/10.x/reverbrestart.md
+
+### `php artisan reverb:start`
+
+Start the Reverb server
+
+```bash
+php artisan reverb:start [--host [HOST]] [--port [PORT]] [--path [PATH]] [--hostname [HOSTNAME]] [--debug]
+```
+
+Options:
+- `--debug` — Indicates whether debug messages should be displayed in the terminal
+- `--host` (value optional) — The IP address the server should bind to
+- `--hostname` (value optional) — The hostname the server is accessible from
+- `--path` (value optional) — The path the server should prefix to all routes
+- `--port` (value optional) — The port the server should listen on
+
+Source: https://artisan.page/10.x/reverbstart.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/10.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/10.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--json] [--method [METHOD]] [--name [NAME]] [--domain [DOMAIN]] [--path [PATH]] [--except-path [EXCEPT-PATH]] [-r|--reverse] [--sort [SORT]] [--except-vendor] [--only-vendor]
+```
+
+Options:
+- `--domain` (value optional) — Filter the routes by domain
+- `--except-path` (value optional) — Do not display the routes matching the given path pattern
+- `--except-vendor` — Do not display routes defined by vendor packages
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--name` (value optional) — Filter the routes by name
+- `--only-vendor` — Only display routes defined by vendor packages
+- `--path` (value optional) — Only show routes matching the given path pattern
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware) to sort by; default: `uri`
+
+Source: https://artisan.page/10.x/routelist.md
+
+### `php artisan sail:add`
+
+Add a service to an existing Sail installation
+
+```bash
+php artisan sail:add [<services>]
+```
+
+Arguments:
+- `services` — The services that should be added
+
+Source: https://artisan.page/10.x/sailadd.md
+
+### `php artisan sail:install`
+
+Install Laravel Sail's default Docker Compose file
+
+```bash
+php artisan sail:install [--with [WITH]] [--devcontainer] [--php [PHP]]
+```
+
+Options:
+- `--devcontainer` — Create a .devcontainer configuration directory
+- `--php` (value optional) — The PHP version that should be used; default: `8.5`
+- `--with` (value optional) — The services that should be included in the installation
+
+Source: https://artisan.page/10.x/sailinstall.md
+
+### `php artisan sail:publish`
+
+Publish the Laravel Sail Docker files
+
+```bash
+php artisan sail:publish
+```
+
+Source: https://artisan.page/10.x/sailpublish.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens; default: `24`
+
+Source: https://artisan.page/10.x/sanctumprune-expired.md
+
+### `php artisan schedule:clear-cache`
+
+Delete the cached mutex files created by scheduler
+
+```bash
+php artisan schedule:clear-cache
+```
+
+Source: https://artisan.page/10.x/scheduleclear-cache.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/10.x/schedulefinish.md
+
+### `php artisan schedule:interrupt`
+
+Interrupt the current schedule run
+
+```bash
+php artisan schedule:interrupt
+```
+
+Source: https://artisan.page/10.x/scheduleinterrupt.md
+
+### `php artisan schedule:list`
+
+List all scheduled tasks
+
+```bash
+php artisan schedule:list [--timezone [TIMEZONE]] [--next]
+```
+
+Options:
+- `--next` — Sort the listed tasks by their next due date
+- `--timezone` (value optional) — The timezone that times should be displayed in
+
+Source: https://artisan.page/10.x/schedulelist.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run
+```
+
+Source: https://artisan.page/10.x/schedulerun.md
+
+### `php artisan schedule:test`
+
+Run a scheduled command
+
+```bash
+php artisan schedule:test [--name [NAME]]
+```
+
+Options:
+- `--name` (value optional) — The name of the scheduled command to run
+
+Source: https://artisan.page/10.x/scheduletest.md
+
+### `php artisan schedule:work`
+
+Start the schedule worker
+
+```bash
+php artisan schedule:work [--run-output-file [RUN-OUTPUT-FILE]]
+```
+
+Options:
+- `--run-output-file` (value optional) — The file to direct <info>schedule:run</info> output to
+
+Source: https://artisan.page/10.x/schedulework.md
+
+### `php artisan schema:dump`
+
+Dump the given database schema
+
+```bash
+php artisan schema:dump [--database [DATABASE]] [--path [PATH]] [--prune]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path where the schema dump file should be stored
+- `--prune` — Delete all existing migration files
+
+Source: https://artisan.page/10.x/schemadump.md
+
+### `php artisan scout:delete-all-indexes`
+
+Delete all indexes
+
+```bash
+php artisan scout:delete-all-indexes
+```
+
+Source: https://artisan.page/10.x/scoutdelete-all-indexes.md
+
+### `php artisan scout:delete-index`
+
+Delete an index
+
+```bash
+php artisan scout:delete-index <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Source: https://artisan.page/10.x/scoutdelete-index.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required) — Class name of the model to flush
+
+Source: https://artisan.page/10.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [--fresh] [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+- `--fresh` — Flush the index before importing
+
+Source: https://artisan.page/10.x/scoutimport.md
+
+### `php artisan scout:index`
+
+Create an index
+
+```bash
+php artisan scout:index [-k|--key [KEY]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Options:
+- `--key` (value optional) — The name of the primary key
+
+Source: https://artisan.page/10.x/scoutindex.md
+
+### `php artisan scout:queue-import`
+
+Import the given model into the search index via chunked, queued jobs
+
+```bash
+php artisan scout:queue-import [--min [MIN]] [--max [MAX]] [-c|--chunk [CHUNK]] [--queue [QUEUE]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk queue
+
+Options:
+- `--chunk` (value optional) — The number of records to queue in a single job (Defaults to configuration value: `scout.chunk.searchable`)
+- `--max` (value optional) — The maximum ID to queue up to
+- `--min` (value optional) — The minimum ID to start queuing from
+- `--queue` (value optional) — The queue that should be used (Defaults to configuration value: `scout.queue.queue`)
+
+Source: https://artisan.page/10.x/scoutqueue-import.md
+
+### `php artisan scout:sync-index-settings`
+
+Sync your configured index settings with your search engine (Meilisearch)
+
+```bash
+php artisan scout:sync-index-settings [--driver [DRIVER]]
+```
+
+Options:
+- `--driver` (value optional) — The name of the search engine driver (Defaults to configuration value: `scout.driver`)
+
+Source: https://artisan.page/10.x/scoutsync-index-settings.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]] [--no-reload]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--no-reload` — Do not reload the development server on .env file changes
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/10.x/serve.md
+
+### `php artisan session:table`
+
+Create a migration for the session database table
+
+```bash
+php artisan session:table
+```
+
+Source: https://artisan.page/10.x/sessiontable.md
+
+### `php artisan spark:install`
+
+Install all of the Spark resources
+
+```bash
+php artisan spark:install
+```
+
+Source: https://artisan.page/10.x/sparkinstall.md
+
+### `php artisan storage:link`
+
+Create the symbolic links configured for the application
+
+```bash
+php artisan storage:link [--relative] [--force]
+```
+
+Options:
+- `--force` — Recreate existing symbolic links
+- `--relative` — Create the symbolic link using relative paths
+
+Source: https://artisan.page/10.x/storagelink.md
+
+### `php artisan storage:unlink`
+
+Delete existing symbolic links configured for the application
+
+```bash
+php artisan storage:unlink
+```
+
+Source: https://artisan.page/10.x/storageunlink.md
+
+### `php artisan stub:publish`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan stub:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/10.x/stubpublish.md
+
+### `php artisan telescope:clear`
+
+Delete all Telescope data from storage
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/10.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/10.x/telescopeinstall.md
+
+### `php artisan telescope:pause`
+
+Pause all Telescope watchers
+
+```bash
+php artisan telescope:pause
+```
+
+Source: https://artisan.page/10.x/telescopepause.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]] [--keep-exceptions]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data; default: `24`
+- `--keep-exceptions` — Retain exception data
+
+Source: https://artisan.page/10.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/10.x/telescopepublish.md
+
+### `php artisan telescope:resume`
+
+Unpause all Telescope watchers
+
+```bash
+php artisan telescope:resume
+```
+
+Source: https://artisan.page/10.x/telescoperesume.md
+
+### `php artisan test`
+
+Run the application tests
+
+```bash
+php artisan test [--without-tty] [--compact] [--coverage] [--min [MIN]] [-p|--parallel] [--profile] [--recreate-databases] [--drop-databases] [--without-databases]
+```
+
+Options:
+- `--compact` — Indicates whether the compact printer should be used
+- `--coverage` — Indicates whether code coverage information should be collected
+- `--drop-databases` — Indicates if the test databases should be dropped
+- `--min` (value optional) — Indicates the minimum threshold enforcement for code coverage
+- `--parallel` — Indicates if the tests should run in parallel
+- `--profile` — Lists top 10 slowest tests
+- `--recreate-databases` — Indicates if the test databases should be re-created
+- `--without-databases` — Indicates if database configuration should be performed
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/10.x/test.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/10.x/tinker.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/10.x/up.md
+
+### `php artisan vapor:handle`
+
+```bash
+php artisan vapor:handle <payload>
+```
+
+Arguments:
+- `payload` (required)
+
+Source: https://artisan.page/10.x/vaporhandle.md
+
+### `php artisan vapor:health-check`
+
+Check the health of the Vapor application
+
+```bash
+php artisan vapor:health-check
+```
+
+Source: https://artisan.page/10.x/vaporhealth-check.md
+
+### `php artisan vapor:queue-failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan vapor:queue-failed [--limit [LIMIT]] [--page [PAGE]] [--id [ID]] [--queue [QUEUE]] [--query [QUERY]] [--start [START]]
+```
+
+Options:
+- `--id` (value optional) — The job ID filter by
+- `--limit` (value optional) — The number of failed jobs to return
+- `--page` (value optional) — The page of failed jobs to return; default: `1`
+- `--query` (value optional) — The search query to filter by
+- `--queue` (value optional) — The queue to filter by
+- `--start` (value optional) — The start timestamp to filter by
+
+Source: https://artisan.page/10.x/vaporqueue-failed.md
+
+### `php artisan vapor:schedule`
+
+Run the scheduled commands at the beginning of every minute
+
+```bash
+php artisan vapor:schedule
+```
+
+Source: https://artisan.page/10.x/vaporschedule.md
+
+### `php artisan vapor:work`
+
+Process a Vapor job
+
+```bash
+php artisan vapor:work [--delay [DELAY]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--force]
+```
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `0`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/10.x/vaporwork.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--existing] [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/10.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/10.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/10.x/viewclear.md
+
+### `php artisan volt:install`
+
+Install all of the Volt resources
+
+```bash
+php artisan volt:install
+```
+
+Source: https://artisan.page/10.x/voltinstall.md
+
+## Laravel 9.x
+
+163 documented commands.
+
+### `php artisan _complete`
+
+Internal command to provide shell completion suggestions
+
+```bash
+php artisan _complete [-s|--shell SHELL] [-i|--input INPUT] [-c|--current CURRENT] [-S|--symfony SYMFONY]
+```
+
+Options:
+- `--current` (value required) — The index of the "input" array that the cursor is in (e.g. COMP_CWORD)
+- `--input` (value required) — An array of input tokens (e.g. COMP_WORDS or argv)
+- `--shell` (value required) — The shell type ("bash")
+- `--symfony` (value required) — The version of the completion script
+
+Source: https://artisan.page/9.x/_complete.md
+
+### `php artisan about`
+
+Display basic information about your application
+
+```bash
+php artisan about [--only [ONLY]] [--json]
+```
+
+Options:
+- `--json` — Output the information as JSON
+- `--only` (value optional) — The section to display
+
+Source: https://artisan.page/9.x/about.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/9.x/authclear-resets.md
+
+### `php artisan breeze:install`
+
+Install the Breeze controllers and resources
+
+```bash
+php artisan breeze:install [--dark] [--inertia] [--pest] [--ssr] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (blade,react,vue,api)
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages
+- `--dark` — Indicate that dark mode support should be installed
+- `--inertia` — Indicate that the Vue Inertia stack should be installed (Deprecated)
+- `--pest` — Indicate that Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+
+Source: https://artisan.page/9.x/breezeinstall.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/9.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/9.x/cacheforget.md
+
+### `php artisan cache:table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan cache:table
+```
+
+Source: https://artisan.page/9.x/cachetable.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier.
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/9.x/cashierwebhook.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/9.x/clear-compiled.md
+
+### `php artisan completion`
+
+Dump the shell completion script
+
+```bash
+php artisan completion [--debug] [--] [<shell>]
+```
+
+Arguments:
+- `shell` — The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+Options:
+- `--debug` — Tail the completion debug log
+
+Source: https://artisan.page/9.x/completion.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/9.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/9.x/configclear.md
+
+### `php artisan db`
+
+Start a new database CLI session
+
+```bash
+php artisan db [--read] [--write] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The database connection that should be used
+
+Options:
+- `--read` — Connect to the read connection
+- `--write` — Connect to the write connection
+
+Source: https://artisan.page/9.x/db.md
+
+### `php artisan db:monitor`
+
+Monitor the number of connections on the specified database
+
+```bash
+php artisan db:monitor [--databases [DATABASES]] [--max [MAX]]
+```
+
+Options:
+- `--databases` (value optional) — The database connections to monitor
+- `--max` (value optional) — The maximum number of connections that can be open before an event is dispatched
+
+Source: https://artisan.page/9.x/dbmonitor.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force] [--] [<class>]
+```
+
+Arguments:
+- `class` — The class name of the root seeder
+
+Options:
+- `--class` (value optional) — The class name of the root seeder
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/9.x/dbseed.md
+
+### `php artisan db:show`
+
+Display information about the given database
+
+```bash
+php artisan db:show [--database [DATABASE]] [--json] [--counts] [--views]
+```
+
+Options:
+- `--counts` — Show the table row count <bg=red;options=bold> Note: This can be slow on large databases </>
+- `--database` (value optional) — The database connection
+- `--json` — Output the database information as JSON
+- `--views` — Show the database views <bg=red;options=bold> Note: This can be slow on large databases </>
+
+Source: https://artisan.page/9.x/dbshow.md
+
+### `php artisan db:table`
+
+Display information about the given database table
+
+```bash
+php artisan db:table [--database [DATABASE]] [--json] [--] [<table>]
+```
+
+Arguments:
+- `table` — The name of the table
+
+Options:
+- `--database` (value optional) — The database connection
+- `--json` — Output the table information as JSON
+
+Source: https://artisan.page/9.x/dbtable.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/9.x/dbwipe.md
+
+### `php artisan docs`
+
+Access the Laravel documentation
+
+```bash
+php artisan docs [<page> [<section>]]
+```
+
+Arguments:
+- `page` — The documentation page to open
+- `section` — The section of the page to open
+
+Source: https://artisan.page/9.x/docs.md
+
+### `php artisan down`
+
+Put the application into maintenance / demo mode
+
+```bash
+php artisan down [--redirect [REDIRECT]] [--render [RENDER]] [--retry [RETRY]] [--refresh [REFRESH]] [--secret [SECRET]] [--status [STATUS]]
+```
+
+Options:
+- `--redirect` (value optional) — The path that users should be redirected to
+- `--refresh` (value optional) — The number of seconds after which the browser may refresh
+- `--render` (value optional) — The view that should be prerendered for display during maintenance mode
+- `--retry` (value optional) — The number of seconds after which the request may be retried
+- `--secret` (value optional) — The secret phrase that may be used to bypass maintenance mode
+- `--status` (value optional) — The status code that should be used when returning the maintenance mode response
+
+Source: https://artisan.page/9.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/9.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/9.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/9.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/9.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/9.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/9.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/9.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/9.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/9.x/env.md
+
+### `php artisan env:decrypt`
+
+Decrypt an environment file
+
+```bash
+php artisan env:decrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--force] [--path [PATH]] [--filename [FILENAME]]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be decrypted
+- `--filename` (value optional) — Filename of the decrypted file
+- `--force` — Overwrite the existing environment file
+- `--key` (value optional) — The encryption key
+- `--path` (value optional) — Path to write the decrypted file
+
+Source: https://artisan.page/9.x/envdecrypt.md
+
+### `php artisan env:encrypt`
+
+Encrypt an environment file
+
+```bash
+php artisan env:encrypt [--key [KEY]] [--cipher [CIPHER]] [--env [ENV]] [--force]
+```
+
+Options:
+- `--cipher` (value optional) — The encryption cipher
+- `--env` (value optional) — The environment to be encrypted
+- `--force` — Overwrite the existing encrypted environment file
+- `--key` (value optional) — The encryption key
+
+Source: https://artisan.page/9.x/envencrypt.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/9.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/9.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/9.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+
+Source: https://artisan.page/9.x/eventlist.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md)
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/9.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/9.x/horizon.md
+
+### `php artisan horizon:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan horizon:clear [--queue [QUEUE]] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/9.x/horizonclear.md
+
+### `php artisan horizon:clear-metrics`
+
+Delete metrics for all jobs and queues
+
+```bash
+php artisan horizon:clear-metrics
+```
+
+Source: https://artisan.page/9.x/horizonclear-metrics.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/9.x/horizoncontinue.md
+
+### `php artisan horizon:continue-supervisor`
+
+Instruct the supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to resume
+
+Source: https://artisan.page/9.x/horizoncontinue-supervisor.md
+
+### `php artisan horizon:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan horizon:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/9.x/horizonforget.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/9.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/9.x/horizonlist.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/9.x/horizonpause.md
+
+### `php artisan horizon:pause-supervisor`
+
+Pause a supervisor
+
+```bash
+php artisan horizon:pause-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to pause
+
+Source: https://artisan.page/9.x/horizonpause-supervisor.md
+
+### `php artisan horizon:publish`
+
+Publish all of the Horizon resources
+
+```bash
+php artisan horizon:publish
+```
+
+Source: https://artisan.page/9.x/horizonpublish.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge [--signal [SIGNAL]]
+```
+
+Options:
+- `--signal` (value optional) — The signal to send to the rogue processes
+
+Source: https://artisan.page/9.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/9.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/9.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--auto-scaling-strategy [AUTO-SCALING-STRATEGY]] [--balance-cooldown [BALANCE-COOLDOWN]] [--balance-max-shift [BALANCE-MAX-SHIFT]] [--workers-name [WORKERS-NAME]] [--parent-id [PARENT-ID]] [--rest [REST]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--auto-scaling-strategy` (value optional) — If supervisor should scale by jobs or time to complete
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--balance-cooldown` (value optional) — The number of seconds to wait in between auto-scaling attempts
+- `--balance-max-shift` (value optional) — The maximum number of processes to increase or decrease per one scaling
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated)
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping a child process
+- `--max-processes` (value optional) — The maximum number of total workers to start
+- `--max-time` (value optional) — The maximum number of seconds a child process should run
+- `--memory` (value optional) — The memory limit in megabytes
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue
+- `--nice` (value optional) — The process priority
+- `--parent-id` (value optional) — The parent process ID
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available
+- `--timeout` (value optional) — The number of seconds a child process can run
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed
+- `--workers-name` (value optional) — The name that should be assigned to the workers
+
+Source: https://artisan.page/9.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/9.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/9.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/9.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated)
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping
+- `--max-time` (value optional) — The maximum number of seconds the worker should run
+- `--memory` (value optional) — The memory limit in megabytes
+- `--name` (value optional) — The name of the worker
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available
+- `--stop-when-empty` — Stop when the queue is empty
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed
+
+Source: https://artisan.page/9.x/horizonwork.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/9.x/inertiamiddleware.md
+
+### `php artisan inertia:start-ssr`
+
+Start the Inertia SSR server
+
+```bash
+php artisan inertia:start-ssr [--runtime [RUNTIME]]
+```
+
+Options:
+- `--runtime` (value optional) — The runtime to use (`node` or `bun`)
+
+Source: https://artisan.page/9.x/inertiastart-ssr.md
+
+### `php artisan inertia:stop-ssr`
+
+Stop the Inertia SSR server
+
+```bash
+php artisan inertia:stop-ssr
+```
+
+Source: https://artisan.page/9.x/inertiastop-ssr.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/9.x/inspire.md
+
+### `php artisan jetstream:install`
+
+Install the Jetstream components and resources
+
+```bash
+php artisan jetstream:install [--dark] [--teams] [--api] [--verification] [--pest] [--ssr] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (inertia,livewire)
+
+Options:
+- `--api` — Indicates if API support should be installed
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages
+- `--dark` — Indicate that dark mode support should be installed
+- `--pest` — Indicates if Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--teams` — Indicates if team support should be installed
+- `--verification` — Indicates if email verification support should be installed
+
+Source: https://artisan.page/9.x/jetstreaminstall.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/9.x/keygenerate.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--short] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md)
+- `--raw` — To output raw command list
+- `--short` — To skip describing commands' arguments
+
+Source: https://artisan.page/9.x/list.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/9.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:copy`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:copy [--inline] [--force] [--test] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/9.x/livewirecopy.md
+
+### `php artisan livewire:cp`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:cp [--inline] [--force] [--test] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/9.x/livewirecp.md
+
+### `php artisan livewire:delete`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:delete [--inline] [--force] [--test] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/9.x/livewiredelete.md
+
+### `php artisan livewire:discover`
+
+Regenerate Livewire component auto-discovery manifest
+
+```bash
+php artisan livewire:discover
+```
+
+Source: https://artisan.page/9.x/livewirediscover.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional) — If you have several stubs, stored in subfolders
+- `--test`
+
+Source: https://artisan.page/9.x/livewiremake.md
+
+### `php artisan livewire:move`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:move [--force] [--inline] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/9.x/livewiremove.md
+
+### `php artisan livewire:mv`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:mv [--inline] [--force] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/9.x/livewiremv.md
+
+### `php artisan livewire:publish`
+
+Publish Livewire configuration
+
+```bash
+php artisan livewire:publish [--assets] [--config] [--pagination]
+```
+
+Options:
+- `--assets` — Indicates if Livewire's front-end assets should be published
+- `--config` — Indicates if Livewire's config file should be published
+- `--pagination` — Indicates if Livewire's pagination views should be published
+
+Source: https://artisan.page/9.x/livewirepublish.md
+
+### `php artisan livewire:rm`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:rm [--inline] [--force] [--test] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/9.x/livewirerm.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/9.x/livewirestubs.md
+
+### `php artisan livewire:touch`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:touch [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional)
+- `--test`
+
+Source: https://artisan.page/9.x/livewiretouch.md
+
+### `php artisan make:cast`
+
+Create a new custom Eloquent cast class
+
+```bash
+php artisan make:cast [-f|--force] [--inbound] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the cast
+
+Options:
+- `--force` — Create the class even if the cast already exists
+- `--inbound` — Generate an inbound cast class
+
+Source: https://artisan.page/9.x/makecast.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the channel
+
+Options:
+- `--force` — Create the class even if the channel already exists
+
+Source: https://artisan.page/9.x/makechannel.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [-f|--force] [--command [COMMAND]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that should be assigned
+- `--force` — Create the class even if the console command already exists
+- `--pest` — Generate an accompanying Pest test for the Console command
+- `--test` — Generate an accompanying PHPUnit test for the Console command
+
+Source: https://artisan.page/9.x/makecommand.md
+
+### `php artisan make:component`
+
+Create a new view component class
+
+```bash
+php artisan make:component [-f|--force] [--inline] [--view] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the component
+
+Options:
+- `--force` — Create the class even if the component already exists
+- `--inline` — Create a component that renders an inline view
+- `--view` — Create an anonymous component with only a view
+
+Source: https://artisan.page/9.x/makecomponent.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--type TYPE] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [-R|--requests] [-s|--singleton] [--creatable] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the controller
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller
+- `--creatable` — Indicate that a singleton resource should be creatable
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class
+- `--model` (value optional) — Generate a resource controller for the given model
+- `--parent` (value optional) — Generate a nested resource controller class
+- `--pest` — Generate an accompanying Pest test for the Controller
+- `--requests` — Generate FormRequest classes for store and update
+- `--resource` — Generate a resource controller class
+- `--singleton` — Generate a singleton resource controller class
+- `--test` — Generate an accompanying PHPUnit test for the Controller
+- `--type` (value required) — Manually specify the controller stub file to use
+
+Source: https://artisan.page/9.x/makecontroller.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the event
+
+Options:
+- `--force` — Create the class even if the event already exists
+
+Source: https://artisan.page/9.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [-f|--force] [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the exception
+
+Options:
+- `--force` — Create the class even if the exception already exists
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/9.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the factory
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/9.x/makefactory.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [-f|--force] [--sync] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the job
+
+Options:
+- `--force` — Create the class even if the job already exists
+- `--pest` — Generate an accompanying Pest test for the Job
+- `--sync` — Indicates that job should be synchronous
+- `--test` — Generate an accompanying PHPUnit test for the Job
+
+Source: https://artisan.page/9.x/makejob.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [-f|--force] [--queued] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the listener
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--force` — Create the class even if the listener already exists
+- `--pest` — Generate an accompanying Pest test for the Listener
+- `--queued` — Indicates the event listener should be queued
+- `--test` — Generate an accompanying PHPUnit test for the Listener
+
+Source: https://artisan.page/9.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional)
+- `--test`
+
+Source: https://artisan.page/9.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the mailable
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+- `--pest` — Generate an accompanying Pest test for the Mailable
+- `--test` — Generate an accompanying PHPUnit test for the Mailable
+
+Source: https://artisan.page/9.x/makemail.md
+
+### `php artisan make:middleware`
+
+Create a new middleware class
+
+```bash
+php artisan make:middleware [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the middleware
+
+Options:
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--test` — Generate an accompanying PHPUnit test for the Middleware
+
+Source: https://artisan.page/9.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration (Deprecated)
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/9.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [--morph-pivot] [--policy] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [-R|--requests] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the model
+
+Options:
+- `--all` — Generate a migration, seeder, factory, policy, resource controller, and form request classes for the model
+- `--api` — Indicates if the generated controller should be an API resource controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--morph-pivot` — Indicates if the generated model should be a custom polymorphic intermediate table model
+- `--pest` — Generate an accompanying Pest test for the Model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--policy` — Create a new policy for the model
+- `--requests` — Create new form request classes and use them in the resource controller
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder for the model
+- `--test` — Generate an accompanying PHPUnit test for the Model
+
+Source: https://artisan.page/9.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the notification
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+- `--pest` — Generate an accompanying Pest test for the Notification
+- `--test` — Generate an accompanying PHPUnit test for the Notification
+
+Source: https://artisan.page/9.x/makenotification.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-f|--force] [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the observer
+
+Options:
+- `--force` — Create the class even if the observer already exists
+- `--model` (value optional) — The model that the observer applies to
+
+Source: https://artisan.page/9.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-f|--force] [-m|--model [MODEL]] [-g|--guard [GUARD]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the policy
+
+Options:
+- `--force` — Create the class even if the policy already exists
+- `--guard` (value optional) — The guard that the policy relies on
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/9.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the provider
+
+Options:
+- `--force` — Create the class even if the provider already exists
+
+Source: https://artisan.page/9.x/makeprovider.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the request
+
+Options:
+- `--force` — Create the class even if the request already exists
+
+Source: https://artisan.page/9.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-f|--force] [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the resource
+
+Options:
+- `--collection` — Create a resource collection
+- `--force` — Create the class even if the resource already exists
+
+Source: https://artisan.page/9.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule [-f|--force] [-i|--implicit] [--invokable] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the rule
+
+Options:
+- `--force` — Create the class even if the rule already exists
+- `--implicit` — Generate an implicit rule
+- `--invokable` — Generate a single method, invokable rule class
+
+Source: https://artisan.page/9.x/makerule.md
+
+### `php artisan make:scope`
+
+Create a new scope class
+
+```bash
+php artisan make:scope [-f|--force] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the scope
+
+Options:
+- `--force` — Create the class even if the scope already exists
+
+Source: https://artisan.page/9.x/makescope.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the seeder
+
+Source: https://artisan.page/9.x/makeseeder.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [-f|--force] [-u|--unit] [-p|--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the test
+
+Options:
+- `--force` — Create the class even if the test already exists
+- `--pest` — Create a Pest test
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/9.x/maketest.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--pretend] [--seed] [--seeder [SEEDER]] [--step] [--isolated [ISOLATED]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--isolated` (value optional) — Do not run the command if another instance of the command is already running
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/9.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/9.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/9.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/9.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/9.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/9.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--pending] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--pending` — Only list pending migrations
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/9.x/migratestatus.md
+
+### `php artisan model:prune`
+
+Prune models that are no longer needed
+
+```bash
+php artisan model:prune [--model [MODEL]] [--except [EXCEPT]] [--chunk [CHUNK]] [--pretend]
+```
+
+Options:
+- `--chunk` (value optional) — The number of models to retrieve per chunk of models to be deleted
+- `--except` (value optional) — Class names of the models to be excluded from pruning
+- `--model` (value optional) — Class names of the models to be pruned
+- `--pretend` — Display the number of prunable records found instead of deleting them
+
+Source: https://artisan.page/9.x/modelprune.md
+
+### `php artisan model:show`
+
+Show information about an Eloquent model
+
+```bash
+php artisan model:show [--database [DATABASE]] [--json] [--] <model>
+```
+
+Arguments:
+- `model` (required) — The model to show
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--json` — Output the model as JSON
+
+Source: https://artisan.page/9.x/modelshow.md
+
+### `php artisan notifications:table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan notifications:table
+```
+
+Source: https://artisan.page/9.x/notificationstable.md
+
+### `php artisan optimize`
+
+Cache the framework bootstrap files
+
+```bash
+php artisan optimize
+```
+
+Source: https://artisan.page/9.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear
+```
+
+Source: https://artisan.page/9.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/9.x/packagediscover.md
+
+### `php artisan queue:batches-table`
+
+Create a migration for the batches database table
+
+```bash
+php artisan queue:batches-table
+```
+
+Source: https://artisan.page/9.x/queuebatches-table.md
+
+### `php artisan queue:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan queue:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to clear
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/9.x/queueclear.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/9.x/queuefailed.md
+
+### `php artisan queue:failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan queue:failed-table
+```
+
+Source: https://artisan.page/9.x/queuefailed-table.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed job data
+
+Source: https://artisan.page/9.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/9.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated)
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes
+- `--name` (value optional) — The name of the worker
+- `--queue` (value optional) — The queue to listen on
+- `--rest` (value optional) — Number of seconds to rest between jobs
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available
+- `--timeout` (value optional) — The number of seconds a child process can run
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed
+
+Source: https://artisan.page/9.x/queuelisten.md
+
+### `php artisan queue:monitor`
+
+Monitor the size of the specified queues
+
+```bash
+php artisan queue:monitor [--max [MAX]] [--] <queues>
+```
+
+Arguments:
+- `queues` (required) — The names of the queues to monitor
+
+Options:
+- `--max` (value optional) — The maximum number of jobs that can be on the queue before an event is dispatched
+
+Source: https://artisan.page/9.x/queuemonitor.md
+
+### `php artisan queue:prune-batches`
+
+Prune stale entries from the batches database
+
+```bash
+php artisan queue:prune-batches [--hours [HOURS]] [--unfinished [UNFINISHED]] [--cancelled [CANCELLED]]
+```
+
+Options:
+- `--cancelled` (value optional) — The number of hours to retain cancelled batch data
+- `--hours` (value optional) — The number of hours to retain batch data
+- `--unfinished` (value optional) — The number of hours to retain unfinished batch data
+
+Source: https://artisan.page/9.x/queueprune-batches.md
+
+### `php artisan queue:prune-failed`
+
+Prune stale entries from the failed jobs table
+
+```bash
+php artisan queue:prune-failed [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed jobs data
+
+Source: https://artisan.page/9.x/queueprune-failed.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/9.x/queuerestart.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry [--queue [QUEUE]] [--range [RANGE]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the failed job or "all" to retry all jobs
+
+Options:
+- `--queue` (value optional) — Retry all of the failed jobs for the specified queue
+- `--range` (value optional) — Range of job IDs (numeric) to be retried
+
+Source: https://artisan.page/9.x/queueretry.md
+
+### `php artisan queue:retry-batch`
+
+Retry the failed jobs for a batch
+
+```bash
+php artisan queue:retry-batch <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the batch whose failed jobs should be retried
+
+Source: https://artisan.page/9.x/queueretry-batch.md
+
+### `php artisan queue:table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan queue:table
+```
+
+Source: https://artisan.page/9.x/queuetable.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--name [NAME]] [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated)
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping
+- `--max-time` (value optional) — The maximum number of seconds the worker should run
+- `--memory` (value optional) — The memory limit in megabytes
+- `--name` (value optional) — The name of the worker
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available
+- `--stop-when-empty` — Stop when the queue is empty
+- `--timeout` (value optional) — The number of seconds a child process can run
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed
+
+Source: https://artisan.page/9.x/queuework.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/9.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/9.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--json] [--method [METHOD]] [--name [NAME]] [--domain [DOMAIN]] [--path [PATH]] [--except-path [EXCEPT-PATH]] [-r|--reverse] [--sort [SORT]] [--except-vendor] [--only-vendor]
+```
+
+Options:
+- `--domain` (value optional) — Filter the routes by domain
+- `--except-path` (value optional) — Do not display the routes matching the given path pattern
+- `--except-vendor` — Do not display routes defined by vendor packages
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--name` (value optional) — Filter the routes by name
+- `--only-vendor` — Only display routes defined by vendor packages
+- `--path` (value optional) — Only show routes matching the given path pattern
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware) to sort by
+
+Source: https://artisan.page/9.x/routelist.md
+
+### `php artisan sail:add`
+
+Add a service to an existing Sail installation
+
+```bash
+php artisan sail:add [<services>]
+```
+
+Arguments:
+- `services` — The services that should be added
+
+Source: https://artisan.page/9.x/sailadd.md
+
+### `php artisan sail:install`
+
+Install Laravel Sail's default Docker Compose file
+
+```bash
+php artisan sail:install [--with [WITH]] [--devcontainer]
+```
+
+Options:
+- `--devcontainer` — Create a .devcontainer configuration directory
+- `--with` (value optional) — The services that should be included in the installation
+
+Source: https://artisan.page/9.x/sailinstall.md
+
+### `php artisan sail:publish`
+
+Publish the Laravel Sail Docker files
+
+```bash
+php artisan sail:publish
+```
+
+Source: https://artisan.page/9.x/sailpublish.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens
+
+Source: https://artisan.page/9.x/sanctumprune-expired.md
+
+### `php artisan schedule:clear-cache`
+
+Delete the cached mutex files created by scheduler
+
+```bash
+php artisan schedule:clear-cache
+```
+
+Source: https://artisan.page/9.x/scheduleclear-cache.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/9.x/schedulefinish.md
+
+### `php artisan schedule:list`
+
+List all scheduled tasks
+
+```bash
+php artisan schedule:list [--timezone [TIMEZONE]] [--next]
+```
+
+Options:
+- `--next` — Sort the listed tasks by their next due date
+- `--timezone` (value optional) — The timezone that times should be displayed in
+
+Source: https://artisan.page/9.x/schedulelist.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run
+```
+
+Source: https://artisan.page/9.x/schedulerun.md
+
+### `php artisan schedule:test`
+
+Run a scheduled command
+
+```bash
+php artisan schedule:test [--name [NAME]]
+```
+
+Options:
+- `--name` (value optional) — The name of the scheduled command to run
+
+Source: https://artisan.page/9.x/scheduletest.md
+
+### `php artisan schedule:work`
+
+Start the schedule worker
+
+```bash
+php artisan schedule:work [--run-output-file [RUN-OUTPUT-FILE]]
+```
+
+Options:
+- `--run-output-file` (value optional) — The file to direct <info>schedule:run</info> output to
+
+Source: https://artisan.page/9.x/schedulework.md
+
+### `php artisan schema:dump`
+
+Dump the given database schema
+
+```bash
+php artisan schema:dump [--database [DATABASE]] [--path [PATH]] [--prune]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path where the schema dump file should be stored
+- `--prune` — Delete all existing migration files
+
+Source: https://artisan.page/9.x/schemadump.md
+
+### `php artisan scout:delete-all-indexes`
+
+Delete all indexes
+
+```bash
+php artisan scout:delete-all-indexes
+```
+
+Source: https://artisan.page/9.x/scoutdelete-all-indexes.md
+
+### `php artisan scout:delete-index`
+
+Delete an index
+
+```bash
+php artisan scout:delete-index <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Source: https://artisan.page/9.x/scoutdelete-index.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required) — Class name of the model to flush
+
+Source: https://artisan.page/9.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+
+Source: https://artisan.page/9.x/scoutimport.md
+
+### `php artisan scout:index`
+
+Create an index
+
+```bash
+php artisan scout:index [-k|--key [KEY]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Options:
+- `--key` (value optional) — The name of the primary key
+
+Source: https://artisan.page/9.x/scoutindex.md
+
+### `php artisan scout:sync-index-settings`
+
+Sync your configured index settings with your search engine (Meilisearch)
+
+```bash
+php artisan scout:sync-index-settings
+```
+
+Source: https://artisan.page/9.x/scoutsync-index-settings.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]] [--no-reload]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on
+- `--no-reload` — Do not reload the development server on .env file changes
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from
+
+Source: https://artisan.page/9.x/serve.md
+
+### `php artisan session:table`
+
+Create a migration for the session database table
+
+```bash
+php artisan session:table
+```
+
+Source: https://artisan.page/9.x/sessiontable.md
+
+### `php artisan storage:link`
+
+Create the symbolic links configured for the application
+
+```bash
+php artisan storage:link [--relative] [--force]
+```
+
+Options:
+- `--force` — Recreate existing symbolic links
+- `--relative` — Create the symbolic link using relative paths
+
+Source: https://artisan.page/9.x/storagelink.md
+
+### `php artisan stub:publish`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan stub:publish [--existing] [--force]
+```
+
+Options:
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/9.x/stubpublish.md
+
+### `php artisan telescope:clear`
+
+Clear all entries from Telescope
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/9.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/9.x/telescopeinstall.md
+
+### `php artisan telescope:pause`
+
+Pause all Telescope watchers
+
+```bash
+php artisan telescope:pause
+```
+
+Source: https://artisan.page/9.x/telescopepause.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data
+
+Source: https://artisan.page/9.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/9.x/telescopepublish.md
+
+### `php artisan telescope:resume`
+
+Unpause all Telescope watchers
+
+```bash
+php artisan telescope:resume
+```
+
+Source: https://artisan.page/9.x/telescoperesume.md
+
+### `php artisan test`
+
+Run the application tests
+
+```bash
+php artisan test [--without-tty] [--coverage] [--min [MIN]] [-p|--parallel] [--recreate-databases] [--drop-databases]
+```
+
+Options:
+- `--coverage` — Indicates whether code coverage information should be collected
+- `--drop-databases` — Indicates if the test databases should be dropped
+- `--min` (value optional) — Indicates the minimum threshold enforcement for code coverage
+- `--parallel` — Indicates if the tests should run in parallel
+- `--recreate-databases` — Indicates if the test databases should be re-created
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/9.x/test.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/9.x/tinker.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/9.x/up.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--existing] [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--existing` — Publish and overwrite only the files that have already been published
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/9.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/9.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/9.x/viewclear.md
+
+## Laravel 8.x
+
+198 documented commands.
+
+### `php artisan _complete`
+
+Internal command to provide shell completion suggestions
+
+```bash
+php artisan _complete [-s|--shell SHELL] [-i|--input INPUT] [-c|--current CURRENT] [-S|--symfony SYMFONY]
+```
+
+Options:
+- `--current` (value required) — The index of the "input" array that the cursor is in (e.g. COMP_CWORD)
+- `--input` (value required) — An array of input tokens (e.g. COMP_WORDS or argv)
+- `--shell` (value required) — The shell type ("bash")
+- `--symfony` (value required) — The version of the completion script
+
+Source: https://artisan.page/8.x/_complete.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/8.x/authclear-resets.md
+
+### `php artisan breeze:install`
+
+Install the Breeze controllers and resources
+
+```bash
+php artisan breeze:install [--inertia] [--pest] [--ssr] [--composer [COMPOSER]] [--] [<stack>]
+```
+
+Arguments:
+- `stack` — The development stack that should be installed (blade,react,vue,api); default: `blade`
+
+Options:
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--inertia` — Indicate that the Vue Inertia stack should be installed (Deprecated)
+- `--pest` — Indicate that Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+
+Source: https://artisan.page/8.x/breezeinstall.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/8.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/8.x/cacheforget.md
+
+### `php artisan cache:table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan cache:table
+```
+
+Source: https://artisan.page/8.x/cachetable.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier.
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/8.x/cashierwebhook.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/8.x/clear-compiled.md
+
+### `php artisan completion`
+
+Dump the shell completion script
+
+```bash
+php artisan completion [--debug] [--] [<shell>]
+```
+
+Arguments:
+- `shell` — The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+Options:
+- `--debug` — Tail the completion debug log
+
+Source: https://artisan.page/8.x/completion.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/8.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/8.x/configclear.md
+
+### `php artisan db`
+
+Start a new database CLI session
+
+```bash
+php artisan db [--read] [--write] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The database connection that should be used
+
+Options:
+- `--read` — Connect to the read connection
+- `--write` — Connect to the write connection
+
+Source: https://artisan.page/8.x/db.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force] [--] [<class>]
+```
+
+Arguments:
+- `class` — The class name of the root seeder
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `Database\Seeders\DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/8.x/dbseed.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/8.x/dbwipe.md
+
+### `php artisan down`
+
+Put the application into maintenance / demo mode
+
+```bash
+php artisan down [--redirect [REDIRECT]] [--render [RENDER]] [--retry [RETRY]] [--refresh [REFRESH]] [--secret [SECRET]] [--status [STATUS]]
+```
+
+Options:
+- `--redirect` (value optional) — The path that users should be redirected to
+- `--refresh` (value optional) — The number of seconds after which the browser may refresh
+- `--render` (value optional) — The view that should be prerendered for display during maintenance mode
+- `--retry` (value optional) — The number of seconds after which the request may be retried
+- `--secret` (value optional) — The secret phrase that may be used to bypass maintenance mode
+- `--status` (value optional) — The status code that should be used when returning the maintenance mode response; default: `503`
+
+Source: https://artisan.page/8.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/8.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/8.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/8.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/8.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/8.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/8.x/env.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/8.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/8.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/8.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+
+Source: https://artisan.page/8.x/eventlist.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/8.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/8.x/horizon.md
+
+### `php artisan horizon:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan horizon:clear [--queue [QUEUE]] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/8.x/horizonclear.md
+
+### `php artisan horizon:clear-metrics`
+
+Delete metrics for all jobs and queues
+
+```bash
+php artisan horizon:clear-metrics
+```
+
+Source: https://artisan.page/8.x/horizonclear-metrics.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/8.x/horizoncontinue.md
+
+### `php artisan horizon:continue-supervisor`
+
+Instruct the supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to resume
+
+Source: https://artisan.page/8.x/horizoncontinue-supervisor.md
+
+### `php artisan horizon:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan horizon:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/8.x/horizonforget.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/8.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/8.x/horizonlist.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/8.x/horizonpause.md
+
+### `php artisan horizon:pause-supervisor`
+
+Pause a supervisor
+
+```bash
+php artisan horizon:pause-supervisor <name>
+```
+
+Arguments:
+- `name` (required) — The name of the supervisor to pause
+
+Source: https://artisan.page/8.x/horizonpause-supervisor.md
+
+### `php artisan horizon:publish`
+
+Publish all of the Horizon resources
+
+```bash
+php artisan horizon:publish
+```
+
+Source: https://artisan.page/8.x/horizonpublish.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge [--signal [SIGNAL]]
+```
+
+Options:
+- `--signal` (value optional) — The signal to send to the rogue processes; default: `SIGTERM`
+
+Source: https://artisan.page/8.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/8.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/8.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--auto-scaling-strategy [AUTO-SCALING-STRATEGY]] [--balance-cooldown [BALANCE-COOLDOWN]] [--balance-max-shift [BALANCE-MAX-SHIFT]] [--workers-name [WORKERS-NAME]] [--parent-id [PARENT-ID]] [--rest [REST]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--auto-scaling-strategy` (value optional) — If supervisor should scale by jobs or time to complete; default: `time`
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--balance-cooldown` (value optional) — The number of seconds to wait in between auto-scaling attempts; default: `3`
+- `--balance-max-shift` (value optional) — The maximum number of processes to increase or decrease per one scaling; default: `1`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping a child process; default: `0`
+- `--max-processes` (value optional) — The maximum number of total workers to start; default: `1`
+- `--max-time` (value optional) — The maximum number of seconds a child process should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue; default: `1`
+- `--nice` (value optional) — The process priority; default: `0`
+- `--parent-id` (value optional) — The parent process ID; default: `0`
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+- `--workers-name` (value optional) — The name that should be assigned to the workers; default: `default`
+
+Source: https://artisan.page/8.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/8.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/8.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/8.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--queue [QUEUE]] [--sleep [SLEEP]] [--rest [REST]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/8.x/horizonwork.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/8.x/inertiamiddleware.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/8.x/inspire.md
+
+### `php artisan jetstream:install`
+
+Install the Jetstream components and resources
+
+```bash
+php artisan jetstream:install [--teams] [--api] [--verification] [--pest] [--ssr] [--composer [COMPOSER]] [--] <stack>
+```
+
+Arguments:
+- `stack` (required) — The development stack that should be installed (inertia,livewire)
+
+Options:
+- `--api` — Indicates if API support should be installed
+- `--composer` (value optional) — Absolute path to the Composer binary which should be used to install packages; default: `global`
+- `--pest` — Indicates if Pest should be installed
+- `--ssr` — Indicates if Inertia SSR support should be installed
+- `--teams` — Indicates if team support should be installed
+- `--verification` — Indicates if email verification support should be installed
+
+Source: https://artisan.page/8.x/jetstreaminstall.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/8.x/keygenerate.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--short] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+- `--short` — To skip describing commands' arguments
+
+Source: https://artisan.page/8.x/list.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/8.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:copy`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:copy [--inline] [--force] [--test] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/8.x/livewirecopy.md
+
+### `php artisan livewire:cp`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:cp [--inline] [--force] [--test] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/8.x/livewirecp.md
+
+### `php artisan livewire:delete`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:delete [--inline] [--force] [--test] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/8.x/livewiredelete.md
+
+### `php artisan livewire:discover`
+
+Regenerate Livewire component auto-discovery manifest
+
+```bash
+php artisan livewire:discover
+```
+
+Source: https://artisan.page/8.x/livewirediscover.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional) — If you have several stubs, stored in subfolders
+- `--test`
+
+Source: https://artisan.page/8.x/livewiremake.md
+
+### `php artisan livewire:move`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:move [--force] [--inline] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/8.x/livewiremove.md
+
+### `php artisan livewire:mv`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:mv [--inline] [--force] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/8.x/livewiremv.md
+
+### `php artisan livewire:publish`
+
+Publish Livewire configuration
+
+```bash
+php artisan livewire:publish [--assets] [--config] [--pagination]
+```
+
+Options:
+- `--assets` — Indicates if Livewire's front-end assets should be published
+- `--config` — Indicates if Livewire's config file should be published
+- `--pagination` — Indicates if Livewire's pagination views should be published
+
+Source: https://artisan.page/8.x/livewirepublish.md
+
+### `php artisan livewire:rm`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:rm [--inline] [--force] [--test] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/8.x/livewirerm.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/8.x/livewirestubs.md
+
+### `php artisan livewire:touch`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:touch [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional); default: `default`
+- `--test`
+
+Source: https://artisan.page/8.x/livewiretouch.md
+
+### `php artisan make:cast`
+
+Create a new custom Eloquent cast class
+
+```bash
+php artisan make:cast <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/makecast.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/makechannel.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [--command [COMMAND]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that should be assigned; default: `command:name`
+- `--pest` — Generate an accompanying Pest test for the Console command
+- `--test` — Generate an accompanying PHPUnit test for the Console command
+
+Source: https://artisan.page/8.x/makecommand.md
+
+### `php artisan make:component`
+
+Create a new view component class
+
+```bash
+php artisan make:component [--force] [--inline] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the component already exists
+- `--inline` — Create a component that renders an inline view
+
+Source: https://artisan.page/8.x/makecomponent.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--type TYPE] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [-R|--requests] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller.
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class.
+- `--model` (value optional) — Generate a resource controller for the given model.
+- `--parent` (value optional) — Generate a nested resource controller class.
+- `--pest` — Generate an accompanying Pest test for the Controller
+- `--requests` — Generate FormRequest classes for store and update.
+- `--resource` — Generate a resource controller class.
+- `--test` — Generate an accompanying PHPUnit test for the Controller
+- `--type` (value required) — Manually specify the controller stub file to use.
+
+Source: https://artisan.page/8.x/makecontroller.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/8.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/8.x/makefactory.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [--sync] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--pest` — Generate an accompanying Pest test for the Job
+- `--sync` — Indicates that job should be synchronous
+- `--test` — Generate an accompanying PHPUnit test for the Job
+
+Source: https://artisan.page/8.x/makejob.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [--queued] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--pest` — Generate an accompanying Pest test for the Listener
+- `--queued` — Indicates the event listener should be queued
+- `--test` — Generate an accompanying PHPUnit test for the Listener
+
+Source: https://artisan.page/8.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional)
+- `--test`
+
+Source: https://artisan.page/8.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+- `--pest` — Generate an accompanying Pest test for the Mail
+- `--test` — Generate an accompanying PHPUnit test for the Mail
+
+Source: https://artisan.page/8.x/makemail.md
+
+### `php artisan make:middleware`
+
+Create a new middleware class
+
+```bash
+php artisan make:middleware [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--pest` — Generate an accompanying Pest test for the Middleware
+- `--test` — Generate an accompanying PHPUnit test for the Middleware
+
+Source: https://artisan.page/8.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/8.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [--policy] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [-R|--requests] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--all` — Generate a migration, seeder, factory, policy, and resource controller for the model
+- `--api` — Indicates if the generated controller should be an API controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--pest` — Generate an accompanying Pest test for the Model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--policy` — Create a new policy for the model
+- `--requests` — Create new form request classes and use them in the resource controller
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder for the model
+- `--test` — Generate an accompanying PHPUnit test for the Model
+
+Source: https://artisan.page/8.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--test] [--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+- `--pest` — Generate an accompanying Pest test for the Notification
+- `--test` — Generate an accompanying PHPUnit test for the Notification
+
+Source: https://artisan.page/8.x/makenotification.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The model that the observer applies to.
+
+Source: https://artisan.page/8.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-m|--model [MODEL]] [-g|--guard [GUARD]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--guard` (value optional) — The guard that the policy relies on
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/8.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/makeprovider.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--collection` — Create a resource collection
+
+Source: https://artisan.page/8.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule [-i|--implicit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--implicit` — Generate an implicit rule.
+
+Source: https://artisan.page/8.x/makerule.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/makeseeder.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [-u|--unit] [-p|--pest] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--pest` — Create a Pest test.
+- `--unit` — Create a unit test.
+
+Source: https://artisan.page/8.x/maketest.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--pretend] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/8.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--schema-path [SCHEMA-PATH]] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--schema-path` (value optional) — The path to a schema dump file
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/8.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/8.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/8.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/8.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/8.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/8.x/migratestatus.md
+
+### `php artisan model:prune`
+
+Prune models that are no longer needed
+
+```bash
+php artisan model:prune [--model [MODEL]] [--except [EXCEPT]] [--chunk [CHUNK]] [--pretend]
+```
+
+Options:
+- `--chunk` (value optional) — The number of models to retrieve per chunk of models to be deleted; default: `1000`
+- `--except` (value optional) — Class names of the models to be excluded from pruning
+- `--model` (value optional) — Class names of the models to be pruned
+- `--pretend` — Display the number of prunable records found instead of deleting them
+
+Source: https://artisan.page/8.x/modelprune.md
+
+### `php artisan notifications:table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan notifications:table
+```
+
+Source: https://artisan.page/8.x/notificationstable.md
+
+### `php artisan nova:action`
+
+Create a new action class
+
+```bash
+php artisan nova:action [--destructive] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--destructive` — Indicate that the action deletes / destroys resources
+- `--queued` — Indicates the action should be queued
+
+Source: https://artisan.page/8.x/novaaction.md
+
+### `php artisan nova:asset`
+
+Create a new asset
+
+```bash
+php artisan nova:asset <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/8.x/novaasset.md
+
+### `php artisan nova:base-resource`
+
+Create a new base resource class
+
+```bash
+php artisan nova:base-resource <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/novabase-resource.md
+
+### `php artisan nova:card`
+
+Create a new card
+
+```bash
+php artisan nova:card <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/8.x/novacard.md
+
+### `php artisan nova:check-license`
+
+Verify your Nova license key
+
+```bash
+php artisan nova:check-license
+```
+
+Source: https://artisan.page/8.x/novacheck-license.md
+
+### `php artisan nova:custom-filter`
+
+Create a new custom filter
+
+```bash
+php artisan nova:custom-filter <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/8.x/novacustom-filter.md
+
+### `php artisan nova:dashboard`
+
+Create a new dashboard.
+
+```bash
+php artisan nova:dashboard <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/8.x/novadashboard.md
+
+### `php artisan nova:field`
+
+Create a new field
+
+```bash
+php artisan nova:field <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/8.x/novafield.md
+
+### `php artisan nova:filter`
+
+Create a new filter class
+
+```bash
+php artisan nova:filter [--boolean] [--date] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--boolean` — Indicates if the generated filter should be a boolean filter
+- `--date` — Indicates if the generated filter should be a date filter
+
+Source: https://artisan.page/8.x/novafilter.md
+
+### `php artisan nova:install`
+
+Install all of the Nova resources
+
+```bash
+php artisan nova:install
+```
+
+Source: https://artisan.page/8.x/novainstall.md
+
+### `php artisan nova:lens`
+
+Create a new lens class
+
+```bash
+php artisan nova:lens <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/novalens.md
+
+### `php artisan nova:partition`
+
+Create a new metric (partition) class
+
+```bash
+php artisan nova:partition <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/novapartition.md
+
+### `php artisan nova:progress`
+
+Create a new metric (progress) class
+
+```bash
+php artisan nova:progress <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/novaprogress.md
+
+### `php artisan nova:publish`
+
+Publish all of the Nova resources
+
+```bash
+php artisan nova:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/8.x/novapublish.md
+
+### `php artisan nova:repeatable`
+
+Create a new repeatable class
+
+```bash
+php artisan nova:repeatable [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/8.x/novarepeatable.md
+
+### `php artisan nova:resource`
+
+Create a new resource class
+
+```bash
+php artisan nova:resource [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/8.x/novaresource.md
+
+### `php artisan nova:resource-tool`
+
+Create a new resource tool
+
+```bash
+php artisan nova:resource-tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/8.x/novaresource-tool.md
+
+### `php artisan nova:stubs`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan nova:stubs [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/8.x/novastubs.md
+
+### `php artisan nova:table`
+
+Create a new metric (table) class
+
+```bash
+php artisan nova:table <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/novatable.md
+
+### `php artisan nova:tool`
+
+Create a new tool
+
+```bash
+php artisan nova:tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/8.x/novatool.md
+
+### `php artisan nova:translate`
+
+Create translation files for Nova
+
+```bash
+php artisan nova:translate [--force] [--] <language>
+```
+
+Arguments:
+- `language` (required)
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/8.x/novatranslate.md
+
+### `php artisan nova:trend`
+
+Create a new metric (trend) class
+
+```bash
+php artisan nova:trend <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/novatrend.md
+
+### `php artisan nova:upgrade`
+
+Upgrade Laravel Nova 3 to 4
+
+```bash
+php artisan nova:upgrade
+```
+
+Source: https://artisan.page/8.x/novaupgrade.md
+
+### `php artisan nova:user`
+
+Create a new user
+
+```bash
+php artisan nova:user
+```
+
+Source: https://artisan.page/8.x/novauser.md
+
+### `php artisan nova:value`
+
+Create a new metric (single value) class
+
+```bash
+php artisan nova:value <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/8.x/novavalue.md
+
+### `php artisan octane:install`
+
+Install the Octane components and resources
+
+```bash
+php artisan octane:install [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that should be used to serve the application
+
+Source: https://artisan.page/8.x/octaneinstall.md
+
+### `php artisan octane:reload`
+
+Reload the Octane workers
+
+```bash
+php artisan octane:reload [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/8.x/octanereload.md
+
+### `php artisan octane:roadrunner`
+
+Start the Octane RoadRunner server
+
+```bash
+php artisan octane:roadrunner [--host [HOST]] [--port [PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--watch] [--poll] [--log-level [LOG-LEVEL]]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to; default: `127.0.0.1`
+- `--log-level` (value optional) — Log messages at or above the specified log level
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/8.x/octaneroadrunner.md
+
+### `php artisan octane:start`
+
+Start the Octane server
+
+```bash
+php artisan octane:start [--server [SERVER]] [--host [HOST]] [--port [PORT]] [--rpc-host [RPC-HOST]] [--rpc-port [RPC-PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--rr-config [RR-CONFIG]] [--watch] [--poll]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to; default: `127.0.0.1`
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on [default: "8000"]
+- `--rpc-host` (value optional) — The RPC IP address the server should bind to
+- `--rpc-port` (value optional) — The RPC port the server should be available on
+- `--rr-config` (value optional) — The path to the RoadRunner .rr.yaml file
+- `--server` (value optional) — The server that should be used to serve the application
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks; default: `auto`
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/8.x/octanestart.md
+
+### `php artisan octane:status`
+
+Get the current status of the Octane server
+
+```bash
+php artisan octane:status [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/8.x/octanestatus.md
+
+### `php artisan octane:stop`
+
+Stop the Octane server
+
+```bash
+php artisan octane:stop [--server [SERVER]]
+```
+
+Options:
+- `--server` (value optional) — The server that is running the application
+
+Source: https://artisan.page/8.x/octanestop.md
+
+### `php artisan octane:swoole`
+
+Start the Octane Swoole server
+
+```bash
+php artisan octane:swoole [--host [HOST]] [--port [PORT]] [--workers [WORKERS]] [--task-workers [TASK-WORKERS]] [--max-requests [MAX-REQUESTS]] [--watch] [--poll]
+```
+
+Options:
+- `--host` (value optional) — The IP address the server should bind to; default: `127.0.0.1`
+- `--max-requests` (value optional) — The number of requests to process before reloading the server; default: `500`
+- `--poll` — Use file system polling while watching in order to watch files over a network
+- `--port` (value optional) — The port the server should be available on
+- `--task-workers` (value optional) — The number of task workers that should be available to handle tasks; default: `auto`
+- `--watch` — Automatically reload the server when the application is modified
+- `--workers` (value optional) — The number of workers that should be available to handle requests; default: `auto`
+
+Source: https://artisan.page/8.x/octaneswoole.md
+
+### `php artisan optimize`
+
+Cache the framework bootstrap files
+
+```bash
+php artisan optimize
+```
+
+Source: https://artisan.page/8.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear
+```
+
+Source: https://artisan.page/8.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/8.x/packagediscover.md
+
+### `php artisan passport:client`
+
+Create a client for issuing access tokens
+
+```bash
+php artisan passport:client [--personal] [--password] [--client] [--name [NAME]] [--provider [PROVIDER]] [--redirect_uri [REDIRECT_URI]] [--user_id [USER_ID]] [--public]
+```
+
+Options:
+- `--client` — Create a client credentials grant client
+- `--name` (value optional) — The name of the client
+- `--password` — Create a password grant client
+- `--personal` — Create a personal access token client
+- `--provider` (value optional) — The name of the user provider
+- `--public` — Create a public client (Auth code grant type only)
+- `--redirect_uri` (value optional) — The URI to redirect to after authorization
+- `--user_id` (value optional) — The user ID the client should be assigned to
+
+Source: https://artisan.page/8.x/passportclient.md
+
+### `php artisan passport:hash`
+
+Hash all of the existing secrets in the clients table
+
+```bash
+php artisan passport:hash [--force]
+```
+
+Options:
+- `--force` — Force the operation to run without confirmation prompt
+
+Source: https://artisan.page/8.x/passporthash.md
+
+### `php artisan passport:install`
+
+Run the commands necessary to prepare Passport for use
+
+```bash
+php artisan passport:install [--uuids] [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+- `--uuids` — Use UUIDs for all client IDs
+
+Source: https://artisan.page/8.x/passportinstall.md
+
+### `php artisan passport:keys`
+
+Create the encryption keys for API authentication
+
+```bash
+php artisan passport:keys [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/8.x/passportkeys.md
+
+### `php artisan passport:purge`
+
+Purge revoked and / or expired tokens and authentication codes
+
+```bash
+php artisan passport:purge [--revoked] [--expired]
+```
+
+Options:
+- `--expired` — Only purge expired tokens and authentication codes
+- `--revoked` — Only purge revoked tokens and authentication codes
+
+Source: https://artisan.page/8.x/passportpurge.md
+
+### `php artisan queue:batches-table`
+
+Create a migration for the batches database table
+
+```bash
+php artisan queue:batches-table
+```
+
+Source: https://artisan.page/8.x/queuebatches-table.md
+
+### `php artisan queue:clear`
+
+Delete all of the jobs from the specified queue
+
+```bash
+php artisan queue:clear [--queue [QUEUE]] [--force] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to clear
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--queue` (value optional) — The name of the queue to clear
+
+Source: https://artisan.page/8.x/queueclear.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/8.x/queuefailed.md
+
+### `php artisan queue:failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan queue:failed-table
+```
+
+Source: https://artisan.page/8.x/queuefailed-table.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush
+```
+
+Source: https://artisan.page/8.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/8.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--name [NAME]] [--delay [DELAY]] [--backoff [BACKOFF]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--queue` (value optional) — The queue to listen on
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/8.x/queuelisten.md
+
+### `php artisan queue:monitor`
+
+Monitor the size of the specified queues
+
+```bash
+php artisan queue:monitor [--max [MAX]] [--] <queues>
+```
+
+Arguments:
+- `queues` (required) — The names of the queues to monitor
+
+Options:
+- `--max` (value optional) — The maximum number of jobs that can be on the queue before an event is dispatched; default: `1000`
+
+Source: https://artisan.page/8.x/queuemonitor.md
+
+### `php artisan queue:prune-batches`
+
+Prune stale entries from the batches database
+
+```bash
+php artisan queue:prune-batches [--hours [HOURS]] [--unfinished [UNFINISHED]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain batch data; default: `24`
+- `--unfinished` (value optional) — The number of hours to retain unfinished batch data
+
+Source: https://artisan.page/8.x/queueprune-batches.md
+
+### `php artisan queue:prune-failed`
+
+Prune stale entries from the failed jobs table
+
+```bash
+php artisan queue:prune-failed [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain failed jobs data; default: `24`
+
+Source: https://artisan.page/8.x/queueprune-failed.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/8.x/queuerestart.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry [--queue [QUEUE]] [--range [RANGE]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the failed job or "all" to retry all jobs
+
+Options:
+- `--queue` (value optional) — Retry all of the failed jobs for the specified queue
+- `--range` (value optional) — Range of job IDs (numeric) to be retried
+
+Source: https://artisan.page/8.x/queueretry.md
+
+### `php artisan queue:retry-batch`
+
+Retry the failed jobs for a batch
+
+```bash
+php artisan queue:retry-batch <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the batch whose failed jobs should be retried
+
+Source: https://artisan.page/8.x/queueretry-batch.md
+
+### `php artisan queue:table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan queue:table
+```
+
+Source: https://artisan.page/8.x/queuetable.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--name [NAME]] [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--delay [DELAY]] [--backoff [BACKOFF]] [--max-jobs [MAX-JOBS]] [--max-time [MAX-TIME]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--rest [REST]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--backoff` (value optional) — The number of seconds to wait before retrying a job that encountered an uncaught exception; default: `0`
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs (Deprecated); default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-jobs` (value optional) — The number of jobs to process before stopping; default: `0`
+- `--max-time` (value optional) — The maximum number of seconds the worker should run; default: `0`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--name` (value optional) — The name of the worker; default: `default`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--rest` (value optional) — Number of seconds to rest between jobs; default: `0`
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/8.x/queuework.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/8.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/8.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--columns [COLUMNS]] [-c|--compact] [--json] [--method [METHOD]] [--name [NAME]] [--path [PATH]] [--except-path [EXCEPT-PATH]] [-r|--reverse] [--sort [SORT]]
+```
+
+Options:
+- `--columns` (value optional) — Columns to include in the route table
+- `--compact` — Only show method, URI and action columns
+- `--except-path` (value optional) — Do not display the routes matching the given path pattern
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--name` (value optional) — Filter the routes by name
+- `--path` (value optional) — Only show routes matching the given path pattern
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (precedence, domain, method, uri, name, action, middleware) to sort by; default: `uri`
+
+Source: https://artisan.page/8.x/routelist.md
+
+### `php artisan sail:add`
+
+Add a service to an existing Sail installation
+
+```bash
+php artisan sail:add [<services>]
+```
+
+Arguments:
+- `services` — The services that should be added
+
+Source: https://artisan.page/8.x/sailadd.md
+
+### `php artisan sail:install`
+
+Install Laravel Sail's default Docker Compose file
+
+```bash
+php artisan sail:install [--with [WITH]] [--devcontainer]
+```
+
+Options:
+- `--devcontainer` — Create a .devcontainer configuration directory
+- `--with` (value optional) — The services that should be included in the installation
+
+Source: https://artisan.page/8.x/sailinstall.md
+
+### `php artisan sail:publish`
+
+Publish the Laravel Sail Docker files
+
+```bash
+php artisan sail:publish
+```
+
+Source: https://artisan.page/8.x/sailpublish.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours.
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens; default: `24`
+
+Source: https://artisan.page/8.x/sanctumprune-expired.md
+
+### `php artisan schedule:clear-cache`
+
+Delete the cached mutex files created by scheduler
+
+```bash
+php artisan schedule:clear-cache
+```
+
+Source: https://artisan.page/8.x/scheduleclear-cache.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/8.x/schedulefinish.md
+
+### `php artisan schedule:list`
+
+List the scheduled commands
+
+```bash
+php artisan schedule:list [--timezone [TIMEZONE]]
+```
+
+Options:
+- `--timezone` (value optional) — The timezone that times should be displayed in
+
+Source: https://artisan.page/8.x/schedulelist.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run
+```
+
+Source: https://artisan.page/8.x/schedulerun.md
+
+### `php artisan schedule:test`
+
+Run a scheduled command
+
+```bash
+php artisan schedule:test
+```
+
+Source: https://artisan.page/8.x/scheduletest.md
+
+### `php artisan schedule:work`
+
+Start the schedule worker
+
+```bash
+php artisan schedule:work
+```
+
+Source: https://artisan.page/8.x/schedulework.md
+
+### `php artisan schema:dump`
+
+Dump the given database schema
+
+```bash
+php artisan schema:dump [--database [DATABASE]] [--path [PATH]] [--prune]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path where the schema dump file should be stored
+- `--prune` — Delete all existing migration files
+
+Source: https://artisan.page/8.x/schemadump.md
+
+### `php artisan scout:delete-all-indexes`
+
+Delete all indexes
+
+```bash
+php artisan scout:delete-all-indexes
+```
+
+Source: https://artisan.page/8.x/scoutdelete-all-indexes.md
+
+### `php artisan scout:delete-index`
+
+Delete an index
+
+```bash
+php artisan scout:delete-index <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Source: https://artisan.page/8.x/scoutdelete-index.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required) — Class name of the model to flush
+
+Source: https://artisan.page/8.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+
+Source: https://artisan.page/8.x/scoutimport.md
+
+### `php artisan scout:index`
+
+Create an index
+
+```bash
+php artisan scout:index [-k|--key [KEY]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the index
+
+Options:
+- `--key` (value optional) — The name of the primary key
+
+Source: https://artisan.page/8.x/scoutindex.md
+
+### `php artisan scout:sync-index-settings`
+
+Sync your configured index settings with your search engine (MeiliSearch)
+
+```bash
+php artisan scout:sync-index-settings
+```
+
+Source: https://artisan.page/8.x/scoutsync-index-settings.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]] [--no-reload]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--no-reload` — Do not reload the development server on .env file changes
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/8.x/serve.md
+
+### `php artisan session:table`
+
+Create a migration for the session database table
+
+```bash
+php artisan session:table
+```
+
+Source: https://artisan.page/8.x/sessiontable.md
+
+### `php artisan spark:install`
+
+Install all of the Spark resources
+
+```bash
+php artisan spark:install
+```
+
+Source: https://artisan.page/8.x/sparkinstall.md
+
+### `php artisan storage:link`
+
+Create the symbolic links configured for the application
+
+```bash
+php artisan storage:link [--relative] [--force]
+```
+
+Options:
+- `--force` — Recreate existing symbolic links
+- `--relative` — Create the symbolic link using relative paths
+
+Source: https://artisan.page/8.x/storagelink.md
+
+### `php artisan stub:publish`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan stub:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/8.x/stubpublish.md
+
+### `php artisan telescope:clear`
+
+Delete all Telescope data from storage
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/8.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/8.x/telescopeinstall.md
+
+### `php artisan telescope:pause`
+
+Pause all Telescope watchers
+
+```bash
+php artisan telescope:pause
+```
+
+Source: https://artisan.page/8.x/telescopepause.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]] [--keep-exceptions]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data; default: `24`
+- `--keep-exceptions` — Retain exception data
+
+Source: https://artisan.page/8.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/8.x/telescopepublish.md
+
+### `php artisan telescope:resume`
+
+Unpause all Telescope watchers
+
+```bash
+php artisan telescope:resume
+```
+
+Source: https://artisan.page/8.x/telescoperesume.md
+
+### `php artisan test`
+
+Run the application tests
+
+```bash
+php artisan test [--without-tty] [-p|--parallel] [--recreate-databases]
+```
+
+Options:
+- `--parallel` — Indicates if the tests should run in parallel
+- `--recreate-databases` — Indicates if the test databases should be re-created
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/8.x/test.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/8.x/tinker.md
+
+### `php artisan ui`
+
+Swap the front-end scaffolding for the application
+
+```bash
+php artisan ui [--auth] [--option [OPTION]] [--] <type>
+```
+
+Arguments:
+- `type` (required) — The preset type (bootstrap, vue, react)
+
+Options:
+- `--auth` — Install authentication UI scaffolding
+- `--option` (value optional) — Pass an option to the preset command
+
+Source: https://artisan.page/8.x/ui.md
+
+### `php artisan ui:auth`
+
+Scaffold basic login and registration views and routes
+
+```bash
+php artisan ui:auth [--views] [--force] [--] [<type>]
+```
+
+Arguments:
+- `type` — The preset type (bootstrap); default: `bootstrap`
+
+Options:
+- `--force` — Overwrite existing views by default
+- `--views` — Only scaffold the authentication views
+
+Source: https://artisan.page/8.x/uiauth.md
+
+### `php artisan ui:controllers`
+
+Scaffold the authentication controllers
+
+```bash
+php artisan ui:controllers
+```
+
+Source: https://artisan.page/8.x/uicontrollers.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/8.x/up.md
+
+### `php artisan vapor:handle`
+
+```bash
+php artisan vapor:handle <payload>
+```
+
+Arguments:
+- `payload` (required)
+
+Source: https://artisan.page/8.x/vaporhandle.md
+
+### `php artisan vapor:health-check`
+
+Check the health of the Vapor application
+
+```bash
+php artisan vapor:health-check
+```
+
+Source: https://artisan.page/8.x/vaporhealth-check.md
+
+### `php artisan vapor:queue-failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan vapor:queue-failed [--limit [LIMIT]] [--page [PAGE]] [--id [ID]] [--queue [QUEUE]] [--query [QUERY]] [--start [START]]
+```
+
+Options:
+- `--id` (value optional) — The job ID filter by
+- `--limit` (value optional) — The number of failed jobs to return
+- `--page` (value optional) — The page of failed jobs to return; default: `1`
+- `--query` (value optional) — The search query to filter by
+- `--queue` (value optional) — The queue to filter by
+- `--start` (value optional) — The start timestamp to filter by
+
+Source: https://artisan.page/8.x/vaporqueue-failed.md
+
+### `php artisan vapor:schedule`
+
+Run the scheduled commands at the beginning of every minute
+
+```bash
+php artisan vapor:schedule
+```
+
+Source: https://artisan.page/8.x/vaporschedule.md
+
+### `php artisan vapor:work`
+
+Process a Vapor job
+
+```bash
+php artisan vapor:work [--delay [DELAY]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--force]
+```
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `0`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/8.x/vaporwork.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/8.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/8.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/8.x/viewclear.md
+
+## Laravel 7.x
+
+159 documented commands.
+
+### `php artisan _complete`
+
+Internal command to provide shell completion suggestions
+
+```bash
+php artisan _complete [-s|--shell SHELL] [-i|--input INPUT] [-c|--current CURRENT] [-S|--symfony SYMFONY]
+```
+
+Options:
+- `--current` (value required) — The index of the "input" array that the cursor is in (e.g. COMP_CWORD)
+- `--input` (value required) — An array of input tokens (e.g. COMP_WORDS or argv)
+- `--shell` (value required) — The shell type ("bash")
+- `--symfony` (value required) — The version of the completion script
+
+Source: https://artisan.page/7.x/_complete.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/7.x/authclear-resets.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/7.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/7.x/cacheforget.md
+
+### `php artisan cache:table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan cache:table
+```
+
+Source: https://artisan.page/7.x/cachetable.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier.
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/7.x/cashierwebhook.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/7.x/clear-compiled.md
+
+### `php artisan completion`
+
+Dump the shell completion script
+
+```bash
+php artisan completion [--debug] [--] [<shell>]
+```
+
+Arguments:
+- `shell` — The shell type (e.g. "bash"), the value of the "$SHELL" env var will be used if this is not given
+
+Options:
+- `--debug` — Tail the completion debug log
+
+Source: https://artisan.page/7.x/completion.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/7.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/7.x/configclear.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force]
+```
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/7.x/dbseed.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/7.x/dbwipe.md
+
+### `php artisan down`
+
+Put the application into maintenance mode
+
+```bash
+php artisan down [--message [MESSAGE]] [--retry [RETRY]] [--allow [ALLOW]]
+```
+
+Options:
+- `--allow` (value optional) — IP or networks allowed to access the application while in maintenance mode
+- `--message` (value optional) — The message for the maintenance mode
+- `--retry` (value optional) — The number of seconds after which the request may be retried
+
+Source: https://artisan.page/7.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/7.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/7.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/7.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/7.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/7.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/7.x/env.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/7.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/7.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/7.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+
+Source: https://artisan.page/7.x/eventlist.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/7.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/7.x/horizon.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/7.x/horizoncontinue.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/7.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/7.x/horizonlist.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/7.x/horizonpause.md
+
+### `php artisan horizon:publish`
+
+Publish all of the Horizon resources
+
+```bash
+php artisan horizon:publish
+```
+
+Source: https://artisan.page/7.x/horizonpublish.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge
+```
+
+Source: https://artisan.page/7.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/7.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/7.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--delay` (value optional) — Amount of time to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-processes` (value optional) — The maximum number of total workers to start; default: `1`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue; default: `1`
+- `--nice` (value optional) — The process priority; default: `0`
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/7.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/7.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/7.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/7.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--delay [DELAY]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--queue [QUEUE]] [--sleep [SLEEP]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — Amount of time to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/7.x/horizonwork.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/7.x/inertiamiddleware.md
+
+### `php artisan inertia:start-ssr`
+
+Start the Inertia SSR server
+
+```bash
+php artisan inertia:start-ssr [--runtime [RUNTIME]]
+```
+
+Options:
+- `--runtime` (value optional) — The runtime to use (`node` or `bun`); default: `node`
+
+Source: https://artisan.page/7.x/inertiastart-ssr.md
+
+### `php artisan inertia:stop-ssr`
+
+Stop the Inertia SSR server
+
+```bash
+php artisan inertia:stop-ssr
+```
+
+Source: https://artisan.page/7.x/inertiastop-ssr.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/7.x/inspire.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/7.x/keygenerate.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--short] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+- `--short` — To skip describing commands' arguments
+
+Source: https://artisan.page/7.x/list.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/7.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:copy`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:copy [--inline] [--force] [--test] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/7.x/livewirecopy.md
+
+### `php artisan livewire:cp`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:cp [--inline] [--force] [--test] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/7.x/livewirecp.md
+
+### `php artisan livewire:delete`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:delete [--inline] [--force] [--test] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/7.x/livewiredelete.md
+
+### `php artisan livewire:discover`
+
+Regenerate Livewire component auto-discovery manifest
+
+```bash
+php artisan livewire:discover
+```
+
+Source: https://artisan.page/7.x/livewirediscover.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional) — If you have several stubs, stored in subfolders
+- `--test`
+
+Source: https://artisan.page/7.x/livewiremake.md
+
+### `php artisan livewire:move`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:move [--force] [--inline] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/7.x/livewiremove.md
+
+### `php artisan livewire:mv`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:mv [--inline] [--force] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/7.x/livewiremv.md
+
+### `php artisan livewire:publish`
+
+Publish Livewire configuration
+
+```bash
+php artisan livewire:publish [--assets] [--config] [--pagination]
+```
+
+Options:
+- `--assets` — Indicates if Livewire's front-end assets should be published
+- `--config` — Indicates if Livewire's config file should be published
+- `--pagination` — Indicates if Livewire's pagination views should be published
+
+Source: https://artisan.page/7.x/livewirepublish.md
+
+### `php artisan livewire:rm`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:rm [--inline] [--force] [--test] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--test`
+
+Source: https://artisan.page/7.x/livewirerm.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/7.x/livewirestubs.md
+
+### `php artisan livewire:touch`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:touch [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional); default: `default`
+- `--test`
+
+Source: https://artisan.page/7.x/livewiretouch.md
+
+### `php artisan make:cast`
+
+Create a new custom Eloquent cast class
+
+```bash
+php artisan make:cast <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makecast.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makechannel.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [--command [COMMAND]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that should be assigned; default: `command:name`
+
+Source: https://artisan.page/7.x/makecommand.md
+
+### `php artisan make:component`
+
+Create a new view component class
+
+```bash
+php artisan make:component [--force] [--inline] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the component already exists
+- `--inline` — Create a component that renders an inline view
+
+Source: https://artisan.page/7.x/makecomponent.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller.
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class.
+- `--model` (value optional) — Generate a resource controller for the given model.
+- `--parent` (value optional) — Generate a nested resource controller class.
+- `--resource` — Generate a resource controller class.
+
+Source: https://artisan.page/7.x/makecontroller.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/7.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/7.x/makefactory.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [--sync] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--sync` — Indicates that job should be synchronous
+
+Source: https://artisan.page/7.x/makejob.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--queued` — Indicates the event listener should be queued
+
+Source: https://artisan.page/7.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--force] [--inline] [--test] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional)
+- `--test`
+
+Source: https://artisan.page/7.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+
+Source: https://artisan.page/7.x/makemail.md
+
+### `php artisan make:middleware`
+
+Create a new middleware class
+
+```bash
+php artisan make:middleware <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/7.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--all` — Generate a migration, seeder, factory, and resource controller for the model
+- `--api` — Indicates if the generated controller should be an API controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder file for the model
+
+Source: https://artisan.page/7.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+
+Source: https://artisan.page/7.x/makenotification.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The model that the observer applies to.
+
+Source: https://artisan.page/7.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-m|--model [MODEL]] [-g|--guard [GUARD]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--guard` (value optional) — The guard that the policy relies on
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/7.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makeprovider.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--collection` — Create a resource collection
+
+Source: https://artisan.page/7.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makerule.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/makeseeder.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [--unit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/7.x/maketest.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--seed] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/7.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/7.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/7.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/7.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/7.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/7.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/7.x/migratestatus.md
+
+### `php artisan notifications:table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan notifications:table
+```
+
+Source: https://artisan.page/7.x/notificationstable.md
+
+### `php artisan nova:action`
+
+Create a new action class
+
+```bash
+php artisan nova:action [--destructive] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--destructive` — Indicate that the action deletes / destroys resources
+
+Source: https://artisan.page/7.x/novaaction.md
+
+### `php artisan nova:asset`
+
+Create a new asset
+
+```bash
+php artisan nova:asset <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novaasset.md
+
+### `php artisan nova:base-resource`
+
+Create a new base resource class
+
+```bash
+php artisan nova:base-resource <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/novabase-resource.md
+
+### `php artisan nova:card`
+
+Create a new card
+
+```bash
+php artisan nova:card <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novacard.md
+
+### `php artisan nova:custom-filter`
+
+Create a new custom filter
+
+```bash
+php artisan nova:custom-filter <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novacustom-filter.md
+
+### `php artisan nova:dashboard`
+
+Create a new dashboard.
+
+```bash
+php artisan nova:dashboard <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novadashboard.md
+
+### `php artisan nova:field`
+
+Create a new field
+
+```bash
+php artisan nova:field <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novafield.md
+
+### `php artisan nova:filter`
+
+Create a new filter class
+
+```bash
+php artisan nova:filter [--boolean] [--date] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--boolean` — Indicates if the generated filter should be a boolean filter
+- `--date` — Indicates if the generated filter should be a date filter
+
+Source: https://artisan.page/7.x/novafilter.md
+
+### `php artisan nova:install`
+
+Install all of the Nova resources
+
+```bash
+php artisan nova:install
+```
+
+Source: https://artisan.page/7.x/novainstall.md
+
+### `php artisan nova:lens`
+
+Create a new lens class
+
+```bash
+php artisan nova:lens <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/novalens.md
+
+### `php artisan nova:partition`
+
+Create a new metric (partition) class
+
+```bash
+php artisan nova:partition <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/novapartition.md
+
+### `php artisan nova:publish`
+
+Publish all of the Nova resources
+
+```bash
+php artisan nova:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/7.x/novapublish.md
+
+### `php artisan nova:resource`
+
+Create a new resource class
+
+```bash
+php artisan nova:resource [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/7.x/novaresource.md
+
+### `php artisan nova:resource-tool`
+
+Create a new resource tool
+
+```bash
+php artisan nova:resource-tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novaresource-tool.md
+
+### `php artisan nova:stubs`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan nova:stubs [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/7.x/novastubs.md
+
+### `php artisan nova:theme`
+
+Create a new theme
+
+```bash
+php artisan nova:theme <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novatheme.md
+
+### `php artisan nova:tool`
+
+Create a new tool
+
+```bash
+php artisan nova:tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/7.x/novatool.md
+
+### `php artisan nova:translate`
+
+Create translation files for Nova
+
+```bash
+php artisan nova:translate [--force] [--] <language>
+```
+
+Arguments:
+- `language` (required)
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/7.x/novatranslate.md
+
+### `php artisan nova:trend`
+
+Create a new metric (trend) class
+
+```bash
+php artisan nova:trend <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/novatrend.md
+
+### `php artisan nova:user`
+
+Create a new user
+
+```bash
+php artisan nova:user
+```
+
+Source: https://artisan.page/7.x/novauser.md
+
+### `php artisan nova:value`
+
+Create a new metric (single value) class
+
+```bash
+php artisan nova:value <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/7.x/novavalue.md
+
+### `php artisan optimize`
+
+Cache the framework bootstrap files
+
+```bash
+php artisan optimize
+```
+
+Source: https://artisan.page/7.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear
+```
+
+Source: https://artisan.page/7.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/7.x/packagediscover.md
+
+### `php artisan passport:client`
+
+Create a client for issuing access tokens
+
+```bash
+php artisan passport:client [--personal] [--password] [--client] [--name [NAME]] [--provider [PROVIDER]] [--redirect_uri [REDIRECT_URI]] [--user_id [USER_ID]] [--public]
+```
+
+Options:
+- `--client` — Create a client credentials grant client
+- `--name` (value optional) — The name of the client
+- `--password` — Create a password grant client
+- `--personal` — Create a personal access token client
+- `--provider` (value optional) — The name of the user provider
+- `--public` — Create a public client (Auth code grant type only)
+- `--redirect_uri` (value optional) — The URI to redirect to after authorization
+- `--user_id` (value optional) — The user ID the client should be assigned to
+
+Source: https://artisan.page/7.x/passportclient.md
+
+### `php artisan passport:hash`
+
+Hash all of the existing secrets in the clients table
+
+```bash
+php artisan passport:hash [--force]
+```
+
+Options:
+- `--force` — Force the operation to run without confirmation prompt
+
+Source: https://artisan.page/7.x/passporthash.md
+
+### `php artisan passport:install`
+
+Run the commands necessary to prepare Passport for use
+
+```bash
+php artisan passport:install [--uuids] [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+- `--uuids` — Use UUIDs for all client IDs
+
+Source: https://artisan.page/7.x/passportinstall.md
+
+### `php artisan passport:keys`
+
+Create the encryption keys for API authentication
+
+```bash
+php artisan passport:keys [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/7.x/passportkeys.md
+
+### `php artisan passport:purge`
+
+Purge revoked and / or expired tokens and authentication codes
+
+```bash
+php artisan passport:purge [--revoked] [--expired]
+```
+
+Options:
+- `--expired` — Only purge expired tokens and authentication codes
+- `--revoked` — Only purge revoked tokens and authentication codes
+
+Source: https://artisan.page/7.x/passportpurge.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/7.x/queuefailed.md
+
+### `php artisan queue:failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan queue:failed-table
+```
+
+Source: https://artisan.page/7.x/queuefailed-table.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush
+```
+
+Source: https://artisan.page/7.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/7.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--delay [DELAY]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--queue` (value optional) — The queue to listen on
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/7.x/queuelisten.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/7.x/queuerestart.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry [--range [RANGE]] [--] [<id>...]
+```
+
+Arguments:
+- `id` — The ID of the failed job or "all" to retry all jobs
+
+Options:
+- `--range` (value optional) — Range of job IDs (numeric) to be retried
+
+Source: https://artisan.page/7.x/queueretry.md
+
+### `php artisan queue:table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan queue:table
+```
+
+Source: https://artisan.page/7.x/queuetable.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--delay [DELAY]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/7.x/queuework.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/7.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/7.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--columns [COLUMNS]] [-c|--compact] [--json] [--method [METHOD]] [--name [NAME]] [--path [PATH]] [-r|--reverse] [--sort [SORT]]
+```
+
+Options:
+- `--columns` (value optional) — Columns to include in the route table
+- `--compact` — Only show method, URI and action columns
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--name` (value optional) — Filter the routes by name
+- `--path` (value optional) — Filter the routes by path
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware) to sort by; default: `uri`
+
+Source: https://artisan.page/7.x/routelist.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours.
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens; default: `24`
+
+Source: https://artisan.page/7.x/sanctumprune-expired.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/7.x/schedulefinish.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run
+```
+
+Source: https://artisan.page/7.x/schedulerun.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required)
+
+Source: https://artisan.page/7.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+
+Source: https://artisan.page/7.x/scoutimport.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/7.x/serve.md
+
+### `php artisan session:table`
+
+Create a migration for the session database table
+
+```bash
+php artisan session:table
+```
+
+Source: https://artisan.page/7.x/sessiontable.md
+
+### `php artisan storage:link`
+
+Create the symbolic links configured for the application
+
+```bash
+php artisan storage:link [--relative]
+```
+
+Options:
+- `--relative` — Create the symbolic link using relative paths
+
+Source: https://artisan.page/7.x/storagelink.md
+
+### `php artisan stub:publish`
+
+Publish all stubs that are available for customization
+
+```bash
+php artisan stub:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/7.x/stubpublish.md
+
+### `php artisan telescope:clear`
+
+Clear all entries from Telescope
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/7.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/7.x/telescopeinstall.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data; default: `24`
+
+Source: https://artisan.page/7.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/7.x/telescopepublish.md
+
+### `php artisan test`
+
+Run the application tests
+
+```bash
+php artisan test [--without-tty]
+```
+
+Options:
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/7.x/test.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/7.x/tinker.md
+
+### `php artisan ui`
+
+Swap the front-end scaffolding for the application
+
+```bash
+php artisan ui [--auth] [--option [OPTION]] [--] <type>
+```
+
+Arguments:
+- `type` (required) — The preset type (bootstrap, vue, react)
+
+Options:
+- `--auth` — Install authentication UI scaffolding
+- `--option` (value optional) — Pass an option to the preset command
+
+Source: https://artisan.page/7.x/ui.md
+
+### `php artisan ui:auth`
+
+Scaffold basic login and registration views and routes
+
+```bash
+php artisan ui:auth [--views] [--force] [--] [<type>]
+```
+
+Arguments:
+- `type` — The preset type (bootstrap); default: `bootstrap`
+
+Options:
+- `--force` — Overwrite existing views by default
+- `--views` — Only scaffold the authentication views
+
+Source: https://artisan.page/7.x/uiauth.md
+
+### `php artisan ui:controllers`
+
+Scaffold the authentication controllers
+
+```bash
+php artisan ui:controllers
+```
+
+Source: https://artisan.page/7.x/uicontrollers.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/7.x/up.md
+
+### `php artisan vapor:handle`
+
+```bash
+php artisan vapor:handle <payload>
+```
+
+Arguments:
+- `payload` (required)
+
+Source: https://artisan.page/7.x/vaporhandle.md
+
+### `php artisan vapor:health-check`
+
+Check the health of the Vapor application
+
+```bash
+php artisan vapor:health-check
+```
+
+Source: https://artisan.page/7.x/vaporhealth-check.md
+
+### `php artisan vapor:queue-failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan vapor:queue-failed [--limit [LIMIT]] [--page [PAGE]] [--id [ID]] [--queue [QUEUE]] [--query [QUERY]] [--start [START]]
+```
+
+Options:
+- `--id` (value optional) — The job ID filter by
+- `--limit` (value optional) — The number of failed jobs to return
+- `--page` (value optional) — The page of failed jobs to return; default: `1`
+- `--query` (value optional) — The search query to filter by
+- `--queue` (value optional) — The queue to filter by
+- `--start` (value optional) — The start timestamp to filter by
+
+Source: https://artisan.page/7.x/vaporqueue-failed.md
+
+### `php artisan vapor:schedule`
+
+Run the scheduled commands at the beginning of every minute
+
+```bash
+php artisan vapor:schedule
+```
+
+Source: https://artisan.page/7.x/vaporschedule.md
+
+### `php artisan vapor:work`
+
+Process a Vapor job
+
+```bash
+php artisan vapor:work [--delay [DELAY]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--force]
+```
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `0`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/7.x/vaporwork.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/7.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/7.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/7.x/viewclear.md
+
+## Laravel 6.x
+
+148 documented commands.
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/6.x/authclear-resets.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/6.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/6.x/cacheforget.md
+
+### `php artisan cache:table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan cache:table
+```
+
+Source: https://artisan.page/6.x/cachetable.md
+
+### `php artisan cashier:webhook`
+
+Create the Stripe webhook to interact with Cashier.
+
+```bash
+php artisan cashier:webhook [--disabled] [--url [URL]] [--api-version [API-VERSION]]
+```
+
+Options:
+- `--api-version` (value optional) — The Stripe API version the webhook should use
+- `--disabled` — Immediately disable the webhook after creation
+- `--url` (value optional) — The URL endpoint for the webhook
+
+Source: https://artisan.page/6.x/cashierwebhook.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/6.x/clear-compiled.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/6.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/6.x/configclear.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force]
+```
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/6.x/dbseed.md
+
+### `php artisan db:wipe`
+
+Drop all tables, views, and types
+
+```bash
+php artisan db:wipe [--database [DATABASE]] [--drop-views] [--drop-types] [--force]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/6.x/dbwipe.md
+
+### `php artisan down`
+
+Put the application into maintenance mode
+
+```bash
+php artisan down [--message [MESSAGE]] [--retry [RETRY]] [--allow [ALLOW]]
+```
+
+Options:
+- `--allow` (value optional) — IP or networks allowed to access the application while in maintenance mode
+- `--message` (value optional) — The message for the maintenance mode
+- `--retry` (value optional) — The number of seconds after which the request may be retried
+
+Source: https://artisan.page/6.x/down.md
+
+### `php artisan dusk`
+
+Run the Dusk tests for the application
+
+```bash
+php artisan dusk [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/6.x/dusk.md
+
+### `php artisan dusk:chrome-driver`
+
+Install the ChromeDriver binary
+
+```bash
+php artisan dusk:chrome-driver [--all] [--detect] [--proxy [PROXY]] [--ssl-no-verify] [--] [<version>]
+```
+
+Arguments:
+- `version`
+
+Options:
+- `--all` — Install a ChromeDriver binary for every OS
+- `--detect` — Detect the installed Chrome / Chromium version
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/6.x/duskchrome-driver.md
+
+### `php artisan dusk:component`
+
+Create a new Dusk component class
+
+```bash
+php artisan dusk:component <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/duskcomponent.md
+
+### `php artisan dusk:fails`
+
+Run the failing Dusk tests from the last run and stop on failure
+
+```bash
+php artisan dusk:fails [--browse] [--without-tty] [--pest]
+```
+
+Options:
+- `--browse` — Open a browser instead of using headless mode
+- `--pest` — Run the tests using Pest
+- `--without-tty` — Disable output to TTY
+
+Source: https://artisan.page/6.x/duskfails.md
+
+### `php artisan dusk:install`
+
+Install Dusk into the application
+
+```bash
+php artisan dusk:install [--proxy [PROXY]] [--ssl-no-verify]
+```
+
+Options:
+- `--proxy` (value optional) — The proxy to download the binary through (example: "tcp://127.0.0.1:9000")
+- `--ssl-no-verify` — Bypass SSL certificate verification when installing through a proxy
+
+Source: https://artisan.page/6.x/duskinstall.md
+
+### `php artisan dusk:make`
+
+Create a new Dusk test class
+
+```bash
+php artisan dusk:make <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/duskmake.md
+
+### `php artisan dusk:page`
+
+Create a new Dusk page class
+
+```bash
+php artisan dusk:page <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/duskpage.md
+
+### `php artisan dusk:purge`
+
+Purge dusk test debugging files
+
+```bash
+php artisan dusk:purge
+```
+
+Source: https://artisan.page/6.x/duskpurge.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/6.x/env.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/6.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/6.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/6.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+
+Source: https://artisan.page/6.x/eventlist.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/6.x/help.md
+
+### `php artisan horizon`
+
+Start a master supervisor in the foreground
+
+```bash
+php artisan horizon [--environment [ENVIRONMENT]]
+```
+
+Options:
+- `--environment` (value optional) — The environment name
+
+Source: https://artisan.page/6.x/horizon.md
+
+### `php artisan horizon:assets`
+
+Re-publish the Horizon assets
+
+```bash
+php artisan horizon:assets
+```
+
+Source: https://artisan.page/6.x/horizonassets.md
+
+### `php artisan horizon:continue`
+
+Instruct the master supervisor to continue processing jobs
+
+```bash
+php artisan horizon:continue
+```
+
+Source: https://artisan.page/6.x/horizoncontinue.md
+
+### `php artisan horizon:install`
+
+Install all of the Horizon resources
+
+```bash
+php artisan horizon:install
+```
+
+Source: https://artisan.page/6.x/horizoninstall.md
+
+### `php artisan horizon:list`
+
+List all of the deployed machines
+
+```bash
+php artisan horizon:list
+```
+
+Source: https://artisan.page/6.x/horizonlist.md
+
+### `php artisan horizon:pause`
+
+Pause the master supervisor
+
+```bash
+php artisan horizon:pause
+```
+
+Source: https://artisan.page/6.x/horizonpause.md
+
+### `php artisan horizon:purge`
+
+Terminate any rogue Horizon processes
+
+```bash
+php artisan horizon:purge
+```
+
+Source: https://artisan.page/6.x/horizonpurge.md
+
+### `php artisan horizon:snapshot`
+
+Store a snapshot of the queue metrics
+
+```bash
+php artisan horizon:snapshot
+```
+
+Source: https://artisan.page/6.x/horizonsnapshot.md
+
+### `php artisan horizon:status`
+
+Get the current status of Horizon
+
+```bash
+php artisan horizon:status
+```
+
+Source: https://artisan.page/6.x/horizonstatus.md
+
+### `php artisan horizon:supervisor`
+
+Start a new supervisor
+
+```bash
+php artisan horizon:supervisor [--balance [BALANCE]] [--delay [DELAY]] [--force] [--max-processes [MAX-PROCESSES]] [--min-processes [MIN-PROCESSES]] [--memory [MEMORY]] [--nice [NICE]] [--paused] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] <name> <connection>
+```
+
+Arguments:
+- `name` (required) — The name of supervisor
+- `connection` (required) — The name of the connection to work
+
+Options:
+- `--balance` (value optional) — The balancing strategy the supervisor should apply
+- `--delay` (value optional) — Amount of time to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--max-processes` (value optional) — The maximum number of total workers to start; default: `1`
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--min-processes` (value optional) — The minimum number of workers to assign per queue; default: `1`
+- `--nice` (value optional) — The process priority; default: `0`
+- `--paused` — Start the supervisor in a paused state
+- `--queue` (value optional) — The names of the queues to work
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/6.x/horizonsupervisor.md
+
+### `php artisan horizon:supervisors`
+
+List all of the supervisors
+
+```bash
+php artisan horizon:supervisors
+```
+
+Source: https://artisan.page/6.x/horizonsupervisors.md
+
+### `php artisan horizon:terminate`
+
+Terminate the master supervisor so it can be restarted
+
+```bash
+php artisan horizon:terminate [--wait]
+```
+
+Options:
+- `--wait` — Wait for all workers to terminate
+
+Source: https://artisan.page/6.x/horizonterminate.md
+
+### `php artisan horizon:timeout`
+
+Get the maximum timeout for the given environment
+
+```bash
+php artisan horizon:timeout [<environment>]
+```
+
+Arguments:
+- `environment` — The environment name; default: `production`
+
+Source: https://artisan.page/6.x/horizontimeout.md
+
+### `php artisan horizon:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan horizon:work [--delay [DELAY]] [--daemon] [--force] [--memory [MEMORY]] [--once] [--stop-when-empty] [--queue [QUEUE]] [--sleep [SLEEP]] [--supervisor [SUPERVISOR]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — Amount of time to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--supervisor` (value optional) — The name of the supervisor the worker belongs to
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/6.x/horizonwork.md
+
+### `php artisan inertia:middleware`
+
+Create a new Inertia middleware
+
+```bash
+php artisan inertia:middleware [--force] [--] [<name>]
+```
+
+Arguments:
+- `name` — Name of the Middleware that should be created; default: `HandleInertiaRequests`
+
+Options:
+- `--force` — Create the class even if the Middleware already exists
+
+Source: https://artisan.page/6.x/inertiamiddleware.md
+
+### `php artisan inertia:start-ssr`
+
+Start the Inertia SSR server
+
+```bash
+php artisan inertia:start-ssr [--runtime [RUNTIME]]
+```
+
+Options:
+- `--runtime` (value optional) — The runtime to use (`node` or `bun`); default: `node`
+
+Source: https://artisan.page/6.x/inertiastart-ssr.md
+
+### `php artisan inertia:stop-ssr`
+
+Stop the Inertia SSR server
+
+```bash
+php artisan inertia:stop-ssr
+```
+
+Source: https://artisan.page/6.x/inertiastop-ssr.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/6.x/inspire.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/6.x/keygenerate.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+
+Source: https://artisan.page/6.x/list.md
+
+### `php artisan livewire:configure-s3-upload-cleanup`
+
+Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs.
+
+```bash
+php artisan livewire:configure-s3-upload-cleanup
+```
+
+Source: https://artisan.page/6.x/livewireconfigure-s3-upload-cleanup.md
+
+### `php artisan livewire:copy`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:copy [--inline] [--force] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/6.x/livewirecopy.md
+
+### `php artisan livewire:cp`
+
+Copy a Livewire component
+
+```bash
+php artisan livewire:cp [--inline] [--force] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/6.x/livewirecp.md
+
+### `php artisan livewire:delete`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:delete [--inline] [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/6.x/livewiredelete.md
+
+### `php artisan livewire:discover`
+
+Regenerate Livewire component auto-discovery manifest
+
+```bash
+php artisan livewire:discover
+```
+
+Source: https://artisan.page/6.x/livewirediscover.md
+
+### `php artisan livewire:make`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:make [--force] [--inline] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/6.x/livewiremake.md
+
+### `php artisan livewire:move`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:move [--force] [--inline] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/6.x/livewiremove.md
+
+### `php artisan livewire:mv`
+
+Move a Livewire component
+
+```bash
+php artisan livewire:mv [--inline] [--force] [--] <name> <new-name>
+```
+
+Arguments:
+- `name` (required)
+- `new-name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/6.x/livewiremv.md
+
+### `php artisan livewire:rm`
+
+Delete a Livewire component
+
+```bash
+php artisan livewire:rm [--inline] [--force] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+
+Source: https://artisan.page/6.x/livewirerm.md
+
+### `php artisan livewire:stubs`
+
+Publish Livewire stubs
+
+```bash
+php artisan livewire:stubs
+```
+
+Source: https://artisan.page/6.x/livewirestubs.md
+
+### `php artisan livewire:touch`
+
+Create a new Livewire component
+
+```bash
+php artisan livewire:touch [--force] [--inline] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional); default: `default`
+
+Source: https://artisan.page/6.x/livewiretouch.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/makechannel.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [--command [COMMAND]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that should be assigned; default: `command:name`
+
+Source: https://artisan.page/6.x/makecommand.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [--api] [--force] [-i|--invokable] [-m|--model [MODEL]] [-p|--parent [PARENT]] [-r|--resource] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller.
+- `--force` — Create the class even if the controller already exists
+- `--invokable` — Generate a single method, invokable controller class.
+- `--model` (value optional) — Generate a resource controller for the given model.
+- `--parent` (value optional) — Generate a nested resource controller class.
+- `--resource` — Generate a resource controller class.
+
+Source: https://artisan.page/6.x/makecontroller.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/6.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/6.x/makefactory.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [--sync] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--sync` — Indicates that job should be synchronous
+
+Source: https://artisan.page/6.x/makejob.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--queued` — Indicates the event listener should be queued
+
+Source: https://artisan.page/6.x/makelistener.md
+
+### `php artisan make:livewire`
+
+Create a new Livewire component
+
+```bash
+php artisan make:livewire [--force] [--inline] [--stub [STUB]] [--] <name>
+```
+
+Arguments:
+- `name` (required)
+
+Options:
+- `--force`
+- `--inline`
+- `--stub` (value optional); default: `default`
+
+Source: https://artisan.page/6.x/makelivewire.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+
+Source: https://artisan.page/6.x/makemail.md
+
+### `php artisan make:middleware`
+
+Create a new middleware class
+
+```bash
+php artisan make:middleware <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/6.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [-s|--seed] [-p|--pivot] [-r|--resource] [--api] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--all` — Generate a migration, seeder, factory, and resource controller for the model
+- `--api` — Indicates if the generated controller should be an API controller
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--resource` — Indicates if the generated controller should be a resource controller
+- `--seed` — Create a new seeder file for the model
+
+Source: https://artisan.page/6.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+
+Source: https://artisan.page/6.x/makenotification.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The model that the observer applies to.
+
+Source: https://artisan.page/6.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/6.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/makeprovider.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--collection` — Create a resource collection
+
+Source: https://artisan.page/6.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/makerule.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/makeseeder.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [--unit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/6.x/maketest.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--seed] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/6.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/6.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/6.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/6.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/6.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/6.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/6.x/migratestatus.md
+
+### `php artisan notifications:table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan notifications:table
+```
+
+Source: https://artisan.page/6.x/notificationstable.md
+
+### `php artisan nova:action`
+
+Create a new action class
+
+```bash
+php artisan nova:action [--destructive] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--destructive` — Indicate that the action deletes / destroys resources
+
+Source: https://artisan.page/6.x/novaaction.md
+
+### `php artisan nova:asset`
+
+Create a new asset
+
+```bash
+php artisan nova:asset <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novaasset.md
+
+### `php artisan nova:base-resource`
+
+Create a new base resource class
+
+```bash
+php artisan nova:base-resource <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/novabase-resource.md
+
+### `php artisan nova:card`
+
+Create a new card
+
+```bash
+php artisan nova:card <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novacard.md
+
+### `php artisan nova:custom-filter`
+
+Create a new custom filter
+
+```bash
+php artisan nova:custom-filter <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novacustom-filter.md
+
+### `php artisan nova:dashboard`
+
+Create a new dashboard.
+
+```bash
+php artisan nova:dashboard <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novadashboard.md
+
+### `php artisan nova:field`
+
+Create a new field
+
+```bash
+php artisan nova:field <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novafield.md
+
+### `php artisan nova:filter`
+
+Create a new filter class
+
+```bash
+php artisan nova:filter [--boolean] [--date] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--boolean` — Indicates if the generated filter should be a boolean filter
+- `--date` — Indicates if the generated filter should be a date filter
+
+Source: https://artisan.page/6.x/novafilter.md
+
+### `php artisan nova:install`
+
+Install all of the Nova resources
+
+```bash
+php artisan nova:install
+```
+
+Source: https://artisan.page/6.x/novainstall.md
+
+### `php artisan nova:lens`
+
+Create a new lens class
+
+```bash
+php artisan nova:lens <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/novalens.md
+
+### `php artisan nova:partition`
+
+Create a new metric (partition) class
+
+```bash
+php artisan nova:partition <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/novapartition.md
+
+### `php artisan nova:publish`
+
+Publish all of the Nova resources
+
+```bash
+php artisan nova:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/6.x/novapublish.md
+
+### `php artisan nova:resource`
+
+Create a new resource class
+
+```bash
+php artisan nova:resource [-m|--model MODEL] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value required) — The model class being represented.
+
+Source: https://artisan.page/6.x/novaresource.md
+
+### `php artisan nova:resource-tool`
+
+Create a new resource tool
+
+```bash
+php artisan nova:resource-tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novaresource-tool.md
+
+### `php artisan nova:theme`
+
+Create a new theme
+
+```bash
+php artisan nova:theme <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novatheme.md
+
+### `php artisan nova:tool`
+
+Create a new tool
+
+```bash
+php artisan nova:tool <name>
+```
+
+Arguments:
+- `name` (required)
+
+Source: https://artisan.page/6.x/novatool.md
+
+### `php artisan nova:trend`
+
+Create a new metric (trend) class
+
+```bash
+php artisan nova:trend <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/novatrend.md
+
+### `php artisan nova:user`
+
+Create a new user
+
+```bash
+php artisan nova:user
+```
+
+Source: https://artisan.page/6.x/novauser.md
+
+### `php artisan nova:value`
+
+Create a new metric (single value) class
+
+```bash
+php artisan nova:value <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/6.x/novavalue.md
+
+### `php artisan optimize`
+
+Cache the framework bootstrap files
+
+```bash
+php artisan optimize
+```
+
+Source: https://artisan.page/6.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear
+```
+
+Source: https://artisan.page/6.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/6.x/packagediscover.md
+
+### `php artisan passport:client`
+
+Create a client for issuing access tokens
+
+```bash
+php artisan passport:client [--personal] [--password] [--client] [--name [NAME]] [--provider [PROVIDER]] [--redirect_uri [REDIRECT_URI]] [--user_id [USER_ID]] [--public]
+```
+
+Options:
+- `--client` — Create a client credentials grant client
+- `--name` (value optional) — The name of the client
+- `--password` — Create a password grant client
+- `--personal` — Create a personal access token client
+- `--provider` (value optional) — The name of the user provider
+- `--public` — Create a public client (Auth code grant type only)
+- `--redirect_uri` (value optional) — The URI to redirect to after authorization
+- `--user_id` (value optional) — The user ID the client should be assigned to
+
+Source: https://artisan.page/6.x/passportclient.md
+
+### `php artisan passport:hash`
+
+Hash all of the existing secrets in the clients table
+
+```bash
+php artisan passport:hash [--force]
+```
+
+Options:
+- `--force` — Force the operation to run without confirmation prompt
+
+Source: https://artisan.page/6.x/passporthash.md
+
+### `php artisan passport:install`
+
+Run the commands necessary to prepare Passport for use
+
+```bash
+php artisan passport:install [--uuids] [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+- `--uuids` — Use UUIDs for all client IDs
+
+Source: https://artisan.page/6.x/passportinstall.md
+
+### `php artisan passport:keys`
+
+Create the encryption keys for API authentication
+
+```bash
+php artisan passport:keys [--force] [--length [LENGTH]]
+```
+
+Options:
+- `--force` — Overwrite keys they already exist
+- `--length` (value optional) — The length of the private key; default: `4096`
+
+Source: https://artisan.page/6.x/passportkeys.md
+
+### `php artisan passport:purge`
+
+Purge revoked and / or expired tokens and authentication codes
+
+```bash
+php artisan passport:purge [--revoked] [--expired]
+```
+
+Options:
+- `--expired` — Only purge expired tokens and authentication codes
+- `--revoked` — Only purge revoked tokens and authentication codes
+
+Source: https://artisan.page/6.x/passportpurge.md
+
+### `php artisan preset`
+
+Swap the front-end scaffolding for the application
+
+```bash
+php artisan preset [--option [OPTION]] [--] <type>
+```
+
+Arguments:
+- `type` (required) — The preset type (none, bootstrap, vue, react)
+
+Options:
+- `--option` (value optional) — Pass an option to the preset command
+
+Source: https://artisan.page/6.x/preset.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/6.x/queuefailed.md
+
+### `php artisan queue:failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan queue:failed-table
+```
+
+Source: https://artisan.page/6.x/queuefailed-table.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush
+```
+
+Source: https://artisan.page/6.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/6.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--delay [DELAY]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--queue` (value optional) — The queue to listen on
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/6.x/queuelisten.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/6.x/queuerestart.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry <id>...
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job or "all" to retry all jobs
+
+Source: https://artisan.page/6.x/queueretry.md
+
+### `php artisan queue:table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan queue:table
+```
+
+Source: https://artisan.page/6.x/queuetable.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--delay [DELAY]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `1`
+
+Source: https://artisan.page/6.x/queuework.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/6.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/6.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--columns [COLUMNS]] [-c|--compact] [--json] [--method [METHOD]] [--name [NAME]] [--path [PATH]] [-r|--reverse] [--sort [SORT]]
+```
+
+Options:
+- `--columns` (value optional) — Columns to include in the route table
+- `--compact` — Only show method, URI and action columns
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--name` (value optional) — Filter the routes by name
+- `--path` (value optional) — Filter the routes by path
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware) to sort by; default: `uri`
+
+Source: https://artisan.page/6.x/routelist.md
+
+### `php artisan sanctum:prune-expired`
+
+Prune tokens expired for more than specified number of hours.
+
+```bash
+php artisan sanctum:prune-expired [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain expired Sanctum tokens; default: `24`
+
+Source: https://artisan.page/6.x/sanctumprune-expired.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id> [<code>]
+```
+
+Arguments:
+- `id` (required)
+- `code`; default: `0`
+
+Source: https://artisan.page/6.x/schedulefinish.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run
+```
+
+Source: https://artisan.page/6.x/schedulerun.md
+
+### `php artisan scout:flush`
+
+Flush all of the model's records from the index
+
+```bash
+php artisan scout:flush <model>
+```
+
+Arguments:
+- `model` (required)
+
+Source: https://artisan.page/6.x/scoutflush.md
+
+### `php artisan scout:import`
+
+Import the given model into the search index
+
+```bash
+php artisan scout:import [-c|--chunk [CHUNK]] [--] <model>
+```
+
+Arguments:
+- `model` (required) — Class name of model to bulk import
+
+Options:
+- `--chunk` (value optional) — The number of records to import at a time (Defaults to configuration value: `scout.chunk.searchable`)
+
+Source: https://artisan.page/6.x/scoutimport.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/6.x/serve.md
+
+### `php artisan session:table`
+
+Create a migration for the session database table
+
+```bash
+php artisan session:table
+```
+
+Source: https://artisan.page/6.x/sessiontable.md
+
+### `php artisan storage:link`
+
+Create a symbolic link from "public/storage" to "storage/app/public"
+
+```bash
+php artisan storage:link
+```
+
+Source: https://artisan.page/6.x/storagelink.md
+
+### `php artisan telescope:clear`
+
+Clear all entries from Telescope
+
+```bash
+php artisan telescope:clear
+```
+
+Source: https://artisan.page/6.x/telescopeclear.md
+
+### `php artisan telescope:install`
+
+Install all of the Telescope resources
+
+```bash
+php artisan telescope:install
+```
+
+Source: https://artisan.page/6.x/telescopeinstall.md
+
+### `php artisan telescope:prune`
+
+Prune stale entries from the Telescope database
+
+```bash
+php artisan telescope:prune [--hours [HOURS]]
+```
+
+Options:
+- `--hours` (value optional) — The number of hours to retain Telescope data; default: `24`
+
+Source: https://artisan.page/6.x/telescopeprune.md
+
+### `php artisan telescope:publish`
+
+Publish all of the Telescope resources
+
+```bash
+php artisan telescope:publish [--force]
+```
+
+Options:
+- `--force` — Overwrite any existing files
+
+Source: https://artisan.page/6.x/telescopepublish.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [--execute [EXECUTE]] [--] [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Options:
+- `--execute` (value optional) — Execute the given code using Tinker
+
+Source: https://artisan.page/6.x/tinker.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/6.x/up.md
+
+### `php artisan vapor:handle`
+
+```bash
+php artisan vapor:handle <payload>
+```
+
+Arguments:
+- `payload` (required)
+
+Source: https://artisan.page/6.x/vaporhandle.md
+
+### `php artisan vapor:health-check`
+
+Check the health of the Vapor application
+
+```bash
+php artisan vapor:health-check
+```
+
+Source: https://artisan.page/6.x/vaporhealth-check.md
+
+### `php artisan vapor:queue-failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan vapor:queue-failed [--limit [LIMIT]] [--page [PAGE]] [--id [ID]] [--queue [QUEUE]] [--query [QUERY]] [--start [START]]
+```
+
+Options:
+- `--id` (value optional) — The job ID filter by
+- `--limit` (value optional) — The number of failed jobs to return
+- `--page` (value optional) — The page of failed jobs to return; default: `1`
+- `--query` (value optional) — The search query to filter by
+- `--queue` (value optional) — The queue to filter by
+- `--start` (value optional) — The start timestamp to filter by
+
+Source: https://artisan.page/6.x/vaporqueue-failed.md
+
+### `php artisan vapor:schedule`
+
+Run the scheduled commands at the beginning of every minute
+
+```bash
+php artisan vapor:schedule
+```
+
+Source: https://artisan.page/6.x/vaporschedule.md
+
+### `php artisan vapor:work`
+
+Process a Vapor job
+
+```bash
+php artisan vapor:work [--delay [DELAY]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--force]
+```
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `0`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/6.x/vaporwork.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/6.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/6.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/6.x/viewclear.md
+
+## Laravel 5.x
+
+76 documented commands.
+
+### `php artisan app:name`
+
+Set the application namespace
+
+```bash
+php artisan app:name <name>
+```
+
+Arguments:
+- `name` (required) — The desired namespace
+
+Source: https://artisan.page/5.x/appname.md
+
+### `php artisan auth:clear-resets`
+
+Flush expired password reset tokens
+
+```bash
+php artisan auth:clear-resets [<name>]
+```
+
+Arguments:
+- `name` — The name of the password broker
+
+Source: https://artisan.page/5.x/authclear-resets.md
+
+### `php artisan cache:clear`
+
+Flush the application cache
+
+```bash
+php artisan cache:clear [--tags [TAGS]] [--] [<store>]
+```
+
+Arguments:
+- `store` — The name of the store you would like to clear
+
+Options:
+- `--tags` (value optional) — The cache tags you would like to clear
+
+Source: https://artisan.page/5.x/cacheclear.md
+
+### `php artisan cache:forget`
+
+Remove an item from the cache
+
+```bash
+php artisan cache:forget <key> [<store>]
+```
+
+Arguments:
+- `key` (required) — The key to remove
+- `store` — The store to remove the key from
+
+Source: https://artisan.page/5.x/cacheforget.md
+
+### `php artisan cache:table`
+
+Create a migration for the cache database table
+
+```bash
+php artisan cache:table
+```
+
+Source: https://artisan.page/5.x/cachetable.md
+
+### `php artisan clear-compiled`
+
+Remove the compiled class file
+
+```bash
+php artisan clear-compiled
+```
+
+Source: https://artisan.page/5.x/clear-compiled.md
+
+### `php artisan config:cache`
+
+Create a cache file for faster configuration loading
+
+```bash
+php artisan config:cache
+```
+
+Source: https://artisan.page/5.x/configcache.md
+
+### `php artisan config:clear`
+
+Remove the configuration cache file
+
+```bash
+php artisan config:clear
+```
+
+Source: https://artisan.page/5.x/configclear.md
+
+### `php artisan db:seed`
+
+Seed the database with records
+
+```bash
+php artisan db:seed [--class [CLASS]] [--database [DATABASE]] [--force]
+```
+
+Options:
+- `--class` (value optional) — The class name of the root seeder; default: `DatabaseSeeder`
+- `--database` (value optional) — The database connection to seed
+- `--force` — Force the operation to run when in production
+
+Source: https://artisan.page/5.x/dbseed.md
+
+### `php artisan down`
+
+Put the application into maintenance mode
+
+```bash
+php artisan down [--message [MESSAGE]] [--retry [RETRY]] [--allow [ALLOW]]
+```
+
+Options:
+- `--allow` (value optional) — IP or networks allowed to access the application while in maintenance mode
+- `--message` (value optional) — The message for the maintenance mode
+- `--retry` (value optional) — The number of seconds after which the request may be retried
+
+Source: https://artisan.page/5.x/down.md
+
+### `php artisan dump-server`
+
+Start the dump server to collect dump information.
+
+```bash
+php artisan dump-server [--format [FORMAT]]
+```
+
+Options:
+- `--format` (value optional) — The output format (cli,html).; default: `cli`
+
+Source: https://artisan.page/5.x/dump-server.md
+
+### `php artisan env`
+
+Display the current framework environment
+
+```bash
+php artisan env
+```
+
+Source: https://artisan.page/5.x/env.md
+
+### `php artisan event:cache`
+
+Discover and cache the application's events and listeners
+
+```bash
+php artisan event:cache
+```
+
+Source: https://artisan.page/5.x/eventcache.md
+
+### `php artisan event:clear`
+
+Clear all cached events and listeners
+
+```bash
+php artisan event:clear
+```
+
+Source: https://artisan.page/5.x/eventclear.md
+
+### `php artisan event:generate`
+
+Generate the missing events and listeners based on registration
+
+```bash
+php artisan event:generate
+```
+
+Source: https://artisan.page/5.x/eventgenerate.md
+
+### `php artisan event:list`
+
+List the application's events and listeners
+
+```bash
+php artisan event:list [--event [EVENT]]
+```
+
+Options:
+- `--event` (value optional) — Filter the events by name
+
+Source: https://artisan.page/5.x/eventlist.md
+
+### `php artisan help`
+
+Display help for a command
+
+```bash
+php artisan help [--format FORMAT] [--raw] [--] [<command_name>]
+```
+
+Arguments:
+- `command_name` — The command name; default: `help`
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command help
+
+Source: https://artisan.page/5.x/help.md
+
+### `php artisan inspire`
+
+Display an inspiring quote
+
+```bash
+php artisan inspire
+```
+
+Source: https://artisan.page/5.x/inspire.md
+
+### `php artisan key:generate`
+
+Set the application key
+
+```bash
+php artisan key:generate [--show] [--force]
+```
+
+Options:
+- `--force` — Force the operation to run when in production
+- `--show` — Display the key instead of modifying files
+
+Source: https://artisan.page/5.x/keygenerate.md
+
+### `php artisan list`
+
+List commands
+
+```bash
+php artisan list [--raw] [--format FORMAT] [--] [<namespace>]
+```
+
+Arguments:
+- `namespace` — The namespace name
+
+Options:
+- `--format` (value required) — The output format (txt, xml, json, or md); default: `txt`
+- `--raw` — To output raw command list
+
+Source: https://artisan.page/5.x/list.md
+
+### `php artisan make:auth`
+
+Scaffold basic login and registration views and routes
+
+```bash
+php artisan make:auth [--views] [--force]
+```
+
+Options:
+- `--force` — Overwrite existing views by default
+- `--views` — Only scaffold the authentication views
+
+Source: https://artisan.page/5.x/makeauth.md
+
+### `php artisan make:channel`
+
+Create a new channel class
+
+```bash
+php artisan make:channel <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/5.x/makechannel.md
+
+### `php artisan make:command`
+
+Create a new Artisan command
+
+```bash
+php artisan make:command [--command [COMMAND]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the command
+
+Options:
+- `--command` (value optional) — The terminal command that should be assigned; default: `command:name`
+
+Source: https://artisan.page/5.x/makecommand.md
+
+### `php artisan make:controller`
+
+Create a new controller class
+
+```bash
+php artisan make:controller [-m|--model [MODEL]] [-r|--resource] [-i|--invokable] [-p|--parent [PARENT]] [--api] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--api` — Exclude the create and edit methods from the controller.
+- `--invokable` — Generate a single method, invokable controller class.
+- `--model` (value optional) — Generate a resource controller for the given model.
+- `--parent` (value optional) — Generate a nested resource controller class.
+- `--resource` — Generate a resource controller class.
+
+Source: https://artisan.page/5.x/makecontroller.md
+
+### `php artisan make:event`
+
+Create a new event class
+
+```bash
+php artisan make:event <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/5.x/makeevent.md
+
+### `php artisan make:exception`
+
+Create a new custom exception class
+
+```bash
+php artisan make:exception [--render] [--report] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--render` — Create the exception with an empty render method
+- `--report` — Create the exception with an empty report method
+
+Source: https://artisan.page/5.x/makeexception.md
+
+### `php artisan make:factory`
+
+Create a new model factory
+
+```bash
+php artisan make:factory [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The name of the model
+
+Source: https://artisan.page/5.x/makefactory.md
+
+### `php artisan make:job`
+
+Create a new job class
+
+```bash
+php artisan make:job [--sync] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--sync` — Indicates that job should be synchronous
+
+Source: https://artisan.page/5.x/makejob.md
+
+### `php artisan make:listener`
+
+Create a new event listener class
+
+```bash
+php artisan make:listener [-e|--event [EVENT]] [--queued] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--event` (value optional) — The event class being listened for
+- `--queued` — Indicates the event listener should be queued
+
+Source: https://artisan.page/5.x/makelistener.md
+
+### `php artisan make:mail`
+
+Create a new email class
+
+```bash
+php artisan make:mail [-f|--force] [-m|--markdown [MARKDOWN]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the mailable already exists
+- `--markdown` (value optional) — Create a new Markdown template for the mailable
+
+Source: https://artisan.page/5.x/makemail.md
+
+### `php artisan make:middleware`
+
+Create a new middleware class
+
+```bash
+php artisan make:middleware <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/5.x/makemiddleware.md
+
+### `php artisan make:migration`
+
+Create a new migration file
+
+```bash
+php artisan make:migration [--create [CREATE]] [--table [TABLE]] [--path [PATH]] [--realpath] [--fullpath] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the migration
+
+Options:
+- `--create` (value optional) — The table to be created
+- `--fullpath` — Output the full path of the migration
+- `--path` (value optional) — The location where the migration file should be created
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--table` (value optional) — The table to migrate
+
+Source: https://artisan.page/5.x/makemigration.md
+
+### `php artisan make:model`
+
+Create a new Eloquent model class
+
+```bash
+php artisan make:model [-a|--all] [-c|--controller] [-f|--factory] [--force] [-m|--migration] [-p|--pivot] [-r|--resource] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--all` — Generate a migration, factory, and resource controller for the model
+- `--controller` — Create a new controller for the model
+- `--factory` — Create a new factory for the model
+- `--force` — Create the class even if the model already exists
+- `--migration` — Create a new migration file for the model
+- `--pivot` — Indicates if the generated model should be a custom intermediate table model
+- `--resource` — Indicates if the generated controller should be a resource controller
+
+Source: https://artisan.page/5.x/makemodel.md
+
+### `php artisan make:notification`
+
+Create a new notification class
+
+```bash
+php artisan make:notification [-f|--force] [-m|--markdown [MARKDOWN]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--force` — Create the class even if the notification already exists
+- `--markdown` (value optional) — Create a new Markdown template for the notification
+
+Source: https://artisan.page/5.x/makenotification.md
+
+### `php artisan make:observer`
+
+Create a new observer class
+
+```bash
+php artisan make:observer [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The model that the observer applies to.
+
+Source: https://artisan.page/5.x/makeobserver.md
+
+### `php artisan make:policy`
+
+Create a new policy class
+
+```bash
+php artisan make:policy [-m|--model [MODEL]] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--model` (value optional) — The model that the policy applies to
+
+Source: https://artisan.page/5.x/makepolicy.md
+
+### `php artisan make:provider`
+
+Create a new service provider class
+
+```bash
+php artisan make:provider <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/5.x/makeprovider.md
+
+### `php artisan make:request`
+
+Create a new form request class
+
+```bash
+php artisan make:request <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/5.x/makerequest.md
+
+### `php artisan make:resource`
+
+Create a new resource
+
+```bash
+php artisan make:resource [-c|--collection] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--collection` — Create a resource collection
+
+Source: https://artisan.page/5.x/makeresource.md
+
+### `php artisan make:rule`
+
+Create a new validation rule
+
+```bash
+php artisan make:rule <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/5.x/makerule.md
+
+### `php artisan make:seeder`
+
+Create a new seeder class
+
+```bash
+php artisan make:seeder <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Source: https://artisan.page/5.x/makeseeder.md
+
+### `php artisan make:test`
+
+Create a new test class
+
+```bash
+php artisan make:test [--unit] [--] <name>
+```
+
+Arguments:
+- `name` (required) — The name of the class
+
+Options:
+- `--unit` — Create a unit test
+
+Source: https://artisan.page/5.x/maketest.md
+
+### `php artisan migrate`
+
+Run the database migrations
+
+```bash
+php artisan migrate [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--seed] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/5.x/migrate.md
+
+### `php artisan migrate:fresh`
+
+Drop all tables and re-run all migrations
+
+```bash
+php artisan migrate:fresh [--database [DATABASE]] [--drop-views] [--drop-types] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--drop-types` — Drop all tables and types (Postgres only)
+- `--drop-views` — Drop all tables and views
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` — Force the migrations to be run so they can be rolled back individually
+
+Source: https://artisan.page/5.x/migratefresh.md
+
+### `php artisan migrate:install`
+
+Create the migration repository
+
+```bash
+php artisan migrate:install [--database [DATABASE]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+
+Source: https://artisan.page/5.x/migrateinstall.md
+
+### `php artisan migrate:refresh`
+
+Reset and re-run all migrations
+
+```bash
+php artisan migrate:refresh [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--seed] [--seeder [SEEDER]] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path to the migrations files to be executed
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--seed` — Indicates if the seed task should be re-run
+- `--seeder` (value optional) — The class name of the root seeder
+- `--step` (value optional) — The number of migrations to be reverted & re-run
+
+Source: https://artisan.page/5.x/migraterefresh.md
+
+### `php artisan migrate:reset`
+
+Rollback all database migrations
+
+```bash
+php artisan migrate:reset [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/5.x/migratereset.md
+
+### `php artisan migrate:rollback`
+
+Rollback the last database migration
+
+```bash
+php artisan migrate:rollback [--database [DATABASE]] [--force] [--path [PATH]] [--realpath] [--pretend] [--step [STEP]]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--force` — Force the operation to run when in production
+- `--path` (value optional) — The path(s) to the migrations files to be executed
+- `--pretend` — Dump the SQL queries that would be run
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+- `--step` (value optional) — The number of migrations to be reverted
+
+Source: https://artisan.page/5.x/migraterollback.md
+
+### `php artisan migrate:status`
+
+Show the status of each migration
+
+```bash
+php artisan migrate:status [--database [DATABASE]] [--path [PATH]] [--realpath]
+```
+
+Options:
+- `--database` (value optional) — The database connection to use
+- `--path` (value optional) — The path(s) to the migrations files to use
+- `--realpath` — Indicate any provided migration file paths are pre-resolved absolute paths
+
+Source: https://artisan.page/5.x/migratestatus.md
+
+### `php artisan notifications:table`
+
+Create a migration for the notifications table
+
+```bash
+php artisan notifications:table
+```
+
+Source: https://artisan.page/5.x/notificationstable.md
+
+### `php artisan optimize`
+
+Cache the framework bootstrap files
+
+```bash
+php artisan optimize
+```
+
+Source: https://artisan.page/5.x/optimize.md
+
+### `php artisan optimize:clear`
+
+Remove the cached bootstrap files
+
+```bash
+php artisan optimize:clear
+```
+
+Source: https://artisan.page/5.x/optimizeclear.md
+
+### `php artisan package:discover`
+
+Rebuild the cached package manifest
+
+```bash
+php artisan package:discover
+```
+
+Source: https://artisan.page/5.x/packagediscover.md
+
+### `php artisan preset`
+
+Swap the front-end scaffolding for the application
+
+```bash
+php artisan preset [--option [OPTION]] [--] <type>
+```
+
+Arguments:
+- `type` (required) — The preset type (none, bootstrap, vue, react)
+
+Options:
+- `--option` (value optional) — Pass an option to the preset command
+
+Source: https://artisan.page/5.x/preset.md
+
+### `php artisan queue:failed`
+
+List all of the failed queue jobs
+
+```bash
+php artisan queue:failed
+```
+
+Source: https://artisan.page/5.x/queuefailed.md
+
+### `php artisan queue:failed-table`
+
+Create a migration for the failed queue jobs database table
+
+```bash
+php artisan queue:failed-table
+```
+
+Source: https://artisan.page/5.x/queuefailed-table.md
+
+### `php artisan queue:flush`
+
+Flush all of the failed queue jobs
+
+```bash
+php artisan queue:flush
+```
+
+Source: https://artisan.page/5.x/queueflush.md
+
+### `php artisan queue:forget`
+
+Delete a failed queue job
+
+```bash
+php artisan queue:forget <id>
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job
+
+Source: https://artisan.page/5.x/queueforget.md
+
+### `php artisan queue:listen`
+
+Listen to a given queue
+
+```bash
+php artisan queue:listen [--delay [DELAY]] [--force] [--memory [MEMORY]] [--queue [QUEUE]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of connection
+
+Options:
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--queue` (value optional) — The queue to listen on
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/5.x/queuelisten.md
+
+### `php artisan queue:restart`
+
+Restart queue worker daemons after their current job
+
+```bash
+php artisan queue:restart
+```
+
+Source: https://artisan.page/5.x/queuerestart.md
+
+### `php artisan queue:retry`
+
+Retry a failed queue job
+
+```bash
+php artisan queue:retry <id>...
+```
+
+Arguments:
+- `id` (required) — The ID of the failed job or "all" to retry all jobs
+
+Source: https://artisan.page/5.x/queueretry.md
+
+### `php artisan queue:table`
+
+Create a migration for the queue jobs database table
+
+```bash
+php artisan queue:table
+```
+
+Source: https://artisan.page/5.x/queuetable.md
+
+### `php artisan queue:work`
+
+Start processing jobs on the queue as a daemon
+
+```bash
+php artisan queue:work [--queue [QUEUE]] [--daemon] [--once] [--stop-when-empty] [--delay [DELAY]] [--force] [--memory [MEMORY]] [--sleep [SLEEP]] [--timeout [TIMEOUT]] [--tries [TRIES]] [--] [<connection>]
+```
+
+Arguments:
+- `connection` — The name of the queue connection to work
+
+Options:
+- `--daemon` — Run the worker in daemon mode (Deprecated)
+- `--delay` (value optional) — The number of seconds to delay failed jobs; default: `0`
+- `--force` — Force the worker to run even in maintenance mode
+- `--memory` (value optional) — The memory limit in megabytes; default: `128`
+- `--once` — Only process the next job on the queue
+- `--queue` (value optional) — The names of the queues to work
+- `--sleep` (value optional) — Number of seconds to sleep when no job is available; default: `3`
+- `--stop-when-empty` — Stop when the queue is empty
+- `--timeout` (value optional) — The number of seconds a child process can run; default: `60`
+- `--tries` (value optional) — Number of times to attempt a job before logging it failed; default: `0`
+
+Source: https://artisan.page/5.x/queuework.md
+
+### `php artisan route:cache`
+
+Create a route cache file for faster route registration
+
+```bash
+php artisan route:cache
+```
+
+Source: https://artisan.page/5.x/routecache.md
+
+### `php artisan route:clear`
+
+Remove the route cache file
+
+```bash
+php artisan route:clear
+```
+
+Source: https://artisan.page/5.x/routeclear.md
+
+### `php artisan route:list`
+
+List all registered routes
+
+```bash
+php artisan route:list [--columns [COLUMNS]] [-c|--compact] [--json] [--method [METHOD]] [--name [NAME]] [--path [PATH]] [-r|--reverse] [--sort [SORT]]
+```
+
+Options:
+- `--columns` (value optional) — Columns to include in the route table
+- `--compact` — Only show method, URI and action columns
+- `--json` — Output the route list as JSON
+- `--method` (value optional) — Filter the routes by method
+- `--name` (value optional) — Filter the routes by name
+- `--path` (value optional) — Filter the routes by path
+- `--reverse` — Reverse the ordering of the routes
+- `--sort` (value optional) — The column (domain, method, uri, name, action, middleware) to sort by; default: `uri`
+
+Source: https://artisan.page/5.x/routelist.md
+
+### `php artisan schedule:finish`
+
+Handle the completion of a scheduled command
+
+```bash
+php artisan schedule:finish <id>
+```
+
+Arguments:
+- `id` (required)
+
+Source: https://artisan.page/5.x/schedulefinish.md
+
+### `php artisan schedule:run`
+
+Run the scheduled commands
+
+```bash
+php artisan schedule:run
+```
+
+Source: https://artisan.page/5.x/schedulerun.md
+
+### `php artisan serve`
+
+Serve the application on the PHP development server
+
+```bash
+php artisan serve [--host [HOST]] [--port [PORT]] [--tries [TRIES]]
+```
+
+Options:
+- `--host` (value optional) — The host address to serve the application on; default: `127.0.0.1`
+- `--port` (value optional) — The port to serve the application on
+- `--tries` (value optional) — The max number of ports to attempt to serve from; default: `10`
+
+Source: https://artisan.page/5.x/serve.md
+
+### `php artisan session:table`
+
+Create a migration for the session database table
+
+```bash
+php artisan session:table
+```
+
+Source: https://artisan.page/5.x/sessiontable.md
+
+### `php artisan storage:link`
+
+Create a symbolic link from "public/storage" to "storage/app/public"
+
+```bash
+php artisan storage:link
+```
+
+Source: https://artisan.page/5.x/storagelink.md
+
+### `php artisan tinker`
+
+Interact with your application
+
+```bash
+php artisan tinker [<include>...]
+```
+
+Arguments:
+- `include` — Include file(s) before starting tinker
+
+Source: https://artisan.page/5.x/tinker.md
+
+### `php artisan up`
+
+Bring the application out of maintenance mode
+
+```bash
+php artisan up
+```
+
+Source: https://artisan.page/5.x/up.md
+
+### `php artisan vendor:publish`
+
+Publish any publishable assets from vendor packages
+
+```bash
+php artisan vendor:publish [--force] [--all] [--provider [PROVIDER]] [--tag [TAG]]
+```
+
+Options:
+- `--all` — Publish assets for all service providers without prompt
+- `--force` — Overwrite any existing files
+- `--provider` (value optional) — The service provider that has assets you want to publish
+- `--tag` (value optional) — One or many tags that have assets you want to publish
+
+Source: https://artisan.page/5.x/vendorpublish.md
+
+### `php artisan view:cache`
+
+Compile all of the application's Blade templates
+
+```bash
+php artisan view:cache
+```
+
+Source: https://artisan.page/5.x/viewcache.md
+
+### `php artisan view:clear`
+
+Clear all compiled view files
+
+```bash
+php artisan view:clear
+```
+
+Source: https://artisan.page/5.x/viewclear.md

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,39 +1,1777 @@
 # Artisan.page
 
-> A searchable, bookmarkable cheatsheet for Laravel's Artisan CLI commands.
+> A complete, versioned reference for Laravel's `php artisan` commands.
 
-Artisan.page provides a complete reference for every `php artisan` command available in Laravel, covering versions 5.x through 13.x. Each command page includes the command name, description, synopsis, arguments, and options.
+The latest supported release is Laravel 13.x. Use the version-specific command links below, or read the [complete reference](https://artisan.page/llms-full.txt) for command synopses, arguments, options, defaults, and aliases.
 
-## URL Structure
+## Laravel 13.x (latest)
 
-- Home: https://artisan.page
-- Version listing: https://artisan.page/{version}/ (e.g. https://artisan.page/13.x/)
-- Command detail: https://artisan.page/{version}/{command} (e.g. https://artisan.page/13.x/makemigration)
+- [`php artisan _complete`](https://artisan.page/13.x/_complete.md) — Internal command to provide shell completion suggestions
+- [`php artisan about`](https://artisan.page/13.x/about.md) — Display basic information about your application
+- [`php artisan auth:clear-resets`](https://artisan.page/13.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan boost:add-skill`](https://artisan.page/13.x/boostadd-skill.md) — Add skills from a remote GitHub repository
+- [`php artisan boost:execute-tool`](https://artisan.page/13.x/boostexecute-tool.md) — Execute a Boost MCP tool in isolation (internal command)
+- [`php artisan boost:install`](https://artisan.page/13.x/boostinstall.md)
+- [`php artisan boost:list-skills`](https://artisan.page/13.x/boostlist-skills.md) — List all available skills in the current project
+- [`php artisan boost:mcp`](https://artisan.page/13.x/boostmcp.md) — Starts Laravel Boost (usually from mcp.json)
+- [`php artisan boost:update`](https://artisan.page/13.x/boostupdate.md) — Update the Laravel Boost guidelines & skills to the latest guidance
+- [`php artisan breeze:install`](https://artisan.page/13.x/breezeinstall.md) — Install the Breeze controllers and resources
+- [`php artisan cache:clear`](https://artisan.page/13.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/13.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:prune-stale-tags`](https://artisan.page/13.x/cacheprune-stale-tags.md) — Prune stale cache tags from the cache (Redis only)
+- [`php artisan cashier:webhook`](https://artisan.page/13.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier
+- [`php artisan channel:list`](https://artisan.page/13.x/channellist.md) — List all registered private broadcast channels
+- [`php artisan clear-compiled`](https://artisan.page/13.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan completion`](https://artisan.page/13.x/completion.md) — Dump the shell completion script
+- [`php artisan config:cache`](https://artisan.page/13.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/13.x/configclear.md) — Remove the configuration cache file
+- [`php artisan config:publish`](https://artisan.page/13.x/configpublish.md) — Publish configuration files to your application
+- [`php artisan config:show`](https://artisan.page/13.x/configshow.md) — Display all of the values for a given configuration file or key
+- [`php artisan db`](https://artisan.page/13.x/db.md) — Start a new database CLI session
+- [`php artisan db:monitor`](https://artisan.page/13.x/dbmonitor.md) — Monitor the number of connections on the specified database
+- [`php artisan db:seed`](https://artisan.page/13.x/dbseed.md) — Seed the database with records
+- [`php artisan db:show`](https://artisan.page/13.x/dbshow.md) — Display information about the given database
+- [`php artisan db:table`](https://artisan.page/13.x/dbtable.md) — Display information about the given database table
+- [`php artisan db:wipe`](https://artisan.page/13.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan dev`](https://artisan.page/13.x/dev.md) — Run the dev processes
+- [`php artisan dev:list`](https://artisan.page/13.x/devlist.md) — List the registered dev processes
+- [`php artisan docs`](https://artisan.page/13.x/docs.md) — Access the Laravel documentation
+- [`php artisan down`](https://artisan.page/13.x/down.md) — Put the application into maintenance / demo mode
+- [`php artisan dusk`](https://artisan.page/13.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/13.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/13.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/13.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/13.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/13.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/13.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/13.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/13.x/env.md) — Display the current framework environment
+- [`php artisan env:decrypt`](https://artisan.page/13.x/envdecrypt.md) — Decrypt an environment file
+- [`php artisan env:encrypt`](https://artisan.page/13.x/envencrypt.md) — Encrypt an environment file
+- [`php artisan event:cache`](https://artisan.page/13.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/13.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/13.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/13.x/eventlist.md) — List the application's events and listeners
+- [`php artisan fortify:install`](https://artisan.page/13.x/fortifyinstall.md) — Install all of the Fortify resources
+- [`php artisan help`](https://artisan.page/13.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/13.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:clear`](https://artisan.page/13.x/horizonclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan horizon:clear-metrics`](https://artisan.page/13.x/horizonclear-metrics.md) — Delete metrics for all jobs and queues
+- [`php artisan horizon:continue`](https://artisan.page/13.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:continue-supervisor`](https://artisan.page/13.x/horizoncontinue-supervisor.md) — Instruct the supervisor to continue processing jobs
+- [`php artisan horizon:forget`](https://artisan.page/13.x/horizonforget.md) — Delete a failed queue job
+- [`php artisan horizon:install`](https://artisan.page/13.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/13.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:listen`](https://artisan.page/13.x/horizonlisten.md) — Run Horizon and automatically restart workers on file changes
+- [`php artisan horizon:pause`](https://artisan.page/13.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:pause-supervisor`](https://artisan.page/13.x/horizonpause-supervisor.md) — Pause a supervisor
+- [`php artisan horizon:publish`](https://artisan.page/13.x/horizonpublish.md) — Publish all of the Horizon resources
+- [`php artisan horizon:purge`](https://artisan.page/13.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/13.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/13.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/13.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisor-status`](https://artisan.page/13.x/horizonsupervisor-status.md) — Show the status for a given supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/13.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/13.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/13.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/13.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:check-ssr`](https://artisan.page/13.x/inertiacheck-ssr.md) — Check the Inertia SSR server health status
+- [`php artisan inertia:middleware`](https://artisan.page/13.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inertia:start-ssr`](https://artisan.page/13.x/inertiastart-ssr.md) — Start the Inertia SSR server
+- [`php artisan inertia:stop-ssr`](https://artisan.page/13.x/inertiastop-ssr.md) — Stop the Inertia SSR server
+- [`php artisan inspire`](https://artisan.page/13.x/inspire.md) — Display an inspiring quote
+- [`php artisan install:api`](https://artisan.page/13.x/installapi.md) — Create an API routes file and install Laravel Sanctum or Laravel Passport
+- [`php artisan install:broadcasting`](https://artisan.page/13.x/installbroadcasting.md) — Create a broadcasting channel routes file
+- [`php artisan invoke-serialized-closure`](https://artisan.page/13.x/invoke-serialized-closure.md) — Invoke the given serialized closure
+- [`php artisan jetstream:install`](https://artisan.page/13.x/jetstreaminstall.md) — Install the Jetstream components and resources
+- [`php artisan key:generate`](https://artisan.page/13.x/keygenerate.md) — Set the application key
+- [`php artisan lang:publish`](https://artisan.page/13.x/langpublish.md) — Publish all language files that are available for customization
+- [`php artisan list`](https://artisan.page/13.x/list.md) — List commands
+- [`php artisan livewire:attribute`](https://artisan.page/13.x/livewireattribute.md) — Create a new Livewire attribute class
+- [`php artisan livewire:config`](https://artisan.page/13.x/livewireconfig.md) — Publish Livewire config file
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/13.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+- [`php artisan livewire:convert`](https://artisan.page/13.x/livewireconvert.md) — Convert a Livewire component between single-file and multi-file formats
+- [`php artisan livewire:form`](https://artisan.page/13.x/livewireform.md) — Create a new Livewire form class
+- [`php artisan livewire:layout`](https://artisan.page/13.x/livewirelayout.md) — Create a new app layout file
+- [`php artisan livewire:make`](https://artisan.page/13.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:publish`](https://artisan.page/13.x/livewirepublish.md) — Publish Livewire configuration
+- [`php artisan livewire:stubs`](https://artisan.page/13.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan make:cache-table`](https://artisan.page/13.x/makecache-table.md) — Create a migration for the cache database table
+- [`php artisan make:cast`](https://artisan.page/13.x/makecast.md) — Create a new custom Eloquent cast class
+- [`php artisan make:channel`](https://artisan.page/13.x/makechannel.md) — Create a new channel class
+- [`php artisan make:class`](https://artisan.page/13.x/makeclass.md) — Create a new class
+- [`php artisan make:command`](https://artisan.page/13.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:component`](https://artisan.page/13.x/makecomponent.md) — Create a new view component class
+- [`php artisan make:config`](https://artisan.page/13.x/makeconfig.md) — Create a new configuration file
+- [`php artisan make:controller`](https://artisan.page/13.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:enum`](https://artisan.page/13.x/makeenum.md) — Create a new enum
+- [`php artisan make:event`](https://artisan.page/13.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/13.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/13.x/makefactory.md) — Create a new model factory
+- [`php artisan make:interface`](https://artisan.page/13.x/makeinterface.md) — Create a new interface
+- [`php artisan make:job`](https://artisan.page/13.x/makejob.md) — Create a new job class
+- [`php artisan make:job-middleware`](https://artisan.page/13.x/makejob-middleware.md) — Create a new job middleware class
+- [`php artisan make:listener`](https://artisan.page/13.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/13.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/13.x/makemail.md) — Create a new email class
+- [`php artisan make:mcp-app-resource`](https://artisan.page/13.x/makemcp-app-resource.md) — Create a new MCP app resource class and linked view
+- [`php artisan make:mcp-prompt`](https://artisan.page/13.x/makemcp-prompt.md) — Create a new MCP prompt class
+- [`php artisan make:mcp-resource`](https://artisan.page/13.x/makemcp-resource.md) — Create a new MCP resource class
+- [`php artisan make:mcp-server`](https://artisan.page/13.x/makemcp-server.md) — Create a new MCP server class
+- [`php artisan make:mcp-tool`](https://artisan.page/13.x/makemcp-tool.md) — Create a new MCP tool class
+- [`php artisan make:middleware`](https://artisan.page/13.x/makemiddleware.md) — Create a new HTTP middleware class
+- [`php artisan make:migration`](https://artisan.page/13.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/13.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/13.x/makenotification.md) — Create a new notification class
+- [`php artisan make:notifications-table`](https://artisan.page/13.x/makenotifications-table.md) — Create a migration for the notifications table
+- [`php artisan make:observer`](https://artisan.page/13.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/13.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/13.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:queue-batches-table`](https://artisan.page/13.x/makequeue-batches-table.md) — Create a migration for the batches database table
+- [`php artisan make:queue-failed-table`](https://artisan.page/13.x/makequeue-failed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan make:queue-table`](https://artisan.page/13.x/makequeue-table.md) — Create a migration for the queue jobs database table
+- [`php artisan make:request`](https://artisan.page/13.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/13.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/13.x/makerule.md) — Create a new validation rule
+- [`php artisan make:scope`](https://artisan.page/13.x/makescope.md) — Create a new scope class
+- [`php artisan make:seeder`](https://artisan.page/13.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:session-table`](https://artisan.page/13.x/makesession-table.md) — Create a migration for the session database table
+- [`php artisan make:test`](https://artisan.page/13.x/maketest.md) — Create a new test class
+- [`php artisan make:trait`](https://artisan.page/13.x/maketrait.md) — Create a new trait
+- [`php artisan make:view`](https://artisan.page/13.x/makeview.md) — Create a new view
+- [`php artisan make:volt`](https://artisan.page/13.x/makevolt.md) — Create a new Volt component
+- [`php artisan mcp:inspector`](https://artisan.page/13.x/mcpinspector.md) — Open the MCP Inspector tool to debug and test MCP Servers
+- [`php artisan mcp:start`](https://artisan.page/13.x/mcpstart.md) — Start the MCP Server for a given handle
+- [`php artisan migrate`](https://artisan.page/13.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/13.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/13.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/13.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/13.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/13.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/13.x/migratestatus.md) — Show the status of each migration
+- [`php artisan model:prune`](https://artisan.page/13.x/modelprune.md) — Prune models that are no longer needed
+- [`php artisan model:show`](https://artisan.page/13.x/modelshow.md) — Show information about an Eloquent model
+- [`php artisan nightwatch:agent`](https://artisan.page/13.x/nightwatchagent.md) — Run the Nightwatch agent.
+- [`php artisan nightwatch:deploy`](https://artisan.page/13.x/nightwatchdeploy.md) — Send deployment metadata to Nightwatch.
+- [`php artisan nightwatch:status`](https://artisan.page/13.x/nightwatchstatus.md) — Get the current status of the Nightwatch agent.
+- [`php artisan nova:action`](https://artisan.page/13.x/novaaction.md) — Create a new action class
+- [`php artisan nova:asset`](https://artisan.page/13.x/novaasset.md) — Create a new asset
+- [`php artisan nova:base-resource`](https://artisan.page/13.x/novabase-resource.md) — Create a new base resource class
+- [`php artisan nova:card`](https://artisan.page/13.x/novacard.md) — Create a new card
+- [`php artisan nova:check-license`](https://artisan.page/13.x/novacheck-license.md) — Verify your Nova license key
+- [`php artisan nova:custom-filter`](https://artisan.page/13.x/novacustom-filter.md) — Create a new custom filter
+- [`php artisan nova:dashboard`](https://artisan.page/13.x/novadashboard.md) — Create a new dashboard.
+- [`php artisan nova:field`](https://artisan.page/13.x/novafield.md) — Create a new field
+- [`php artisan nova:filter`](https://artisan.page/13.x/novafilter.md) — Create a new filter class
+- [`php artisan nova:install`](https://artisan.page/13.x/novainstall.md) — Install all of the Nova resources
+- [`php artisan nova:lens`](https://artisan.page/13.x/novalens.md) — Create a new lens class
+- [`php artisan nova:partition`](https://artisan.page/13.x/novapartition.md) — Create a new metric (partition) class
+- [`php artisan nova:policy`](https://artisan.page/13.x/novapolicy.md) — Create a new policy class
+- [`php artisan nova:progress`](https://artisan.page/13.x/novaprogress.md) — Create a new metric (progress) class
+- [`php artisan nova:publish`](https://artisan.page/13.x/novapublish.md) — Publish all of the Nova resources
+- [`php artisan nova:repeatable`](https://artisan.page/13.x/novarepeatable.md) — Create a new repeatable class
+- [`php artisan nova:resource`](https://artisan.page/13.x/novaresource.md) — Create a new resource class
+- [`php artisan nova:resource-tool`](https://artisan.page/13.x/novaresource-tool.md) — Create a new resource tool
+- [`php artisan nova:stubs`](https://artisan.page/13.x/novastubs.md) — Publish all stubs that are available for customization
+- [`php artisan nova:table`](https://artisan.page/13.x/novatable.md) — Create a new metric (table) class
+- [`php artisan nova:tool`](https://artisan.page/13.x/novatool.md) — Create a new tool
+- [`php artisan nova:translate`](https://artisan.page/13.x/novatranslate.md) — Create translation files for Nova
+- [`php artisan nova:trend`](https://artisan.page/13.x/novatrend.md) — Create a new metric (trend) class
+- [`php artisan nova:user`](https://artisan.page/13.x/novauser.md) — Create a new user
+- [`php artisan nova:value`](https://artisan.page/13.x/novavalue.md) — Create a new metric (single value) class
+- [`php artisan octane:frankenphp`](https://artisan.page/13.x/octanefrankenphp.md) — Start the Octane FrankenPHP server
+- [`php artisan octane:install`](https://artisan.page/13.x/octaneinstall.md) — Install the Octane components and resources
+- [`php artisan octane:reload`](https://artisan.page/13.x/octanereload.md) — Reload the Octane workers
+- [`php artisan octane:roadrunner`](https://artisan.page/13.x/octaneroadrunner.md) — Start the Octane RoadRunner server
+- [`php artisan octane:start`](https://artisan.page/13.x/octanestart.md) — Start the Octane server
+- [`php artisan octane:status`](https://artisan.page/13.x/octanestatus.md) — Get the current status of the Octane server
+- [`php artisan octane:stop`](https://artisan.page/13.x/octanestop.md) — Stop the Octane server
+- [`php artisan octane:swoole`](https://artisan.page/13.x/octaneswoole.md) — Start the Octane Swoole server
+- [`php artisan optimize`](https://artisan.page/13.x/optimize.md) — Cache framework bootstrap, configuration, and metadata to increase performance
+- [`php artisan optimize:clear`](https://artisan.page/13.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/13.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan pail`](https://artisan.page/13.x/pail.md) — Tails the application logs
+- [`php artisan passport:client`](https://artisan.page/13.x/passportclient.md) — Create a client for issuing access tokens
+- [`php artisan passport:hash`](https://artisan.page/13.x/passporthash.md) — Hash all of the existing secrets in the clients table
+- [`php artisan passport:install`](https://artisan.page/13.x/passportinstall.md) — Run the commands necessary to prepare Passport for use
+- [`php artisan passport:keys`](https://artisan.page/13.x/passportkeys.md) — Create the encryption keys for API authentication
+- [`php artisan passport:purge`](https://artisan.page/13.x/passportpurge.md) — Purge revoked and / or expired tokens and authentication codes
+- [`php artisan pennant:feature`](https://artisan.page/13.x/pennantfeature.md) — Create a new feature class
+- [`php artisan pennant:purge`](https://artisan.page/13.x/pennantpurge.md) — Delete Pennant features from storage
+- [`php artisan pulse:check`](https://artisan.page/13.x/pulsecheck.md) — Take a snapshot of the current server's pulse
+- [`php artisan pulse:clear`](https://artisan.page/13.x/pulseclear.md) — Delete all Pulse data from storage
+- [`php artisan pulse:restart`](https://artisan.page/13.x/pulserestart.md) — Restart any running "work" and "check" commands
+- [`php artisan pulse:work`](https://artisan.page/13.x/pulsework.md) — Process incoming Pulse data from the ingest stream
+- [`php artisan queue:clear`](https://artisan.page/13.x/queueclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan queue:failed`](https://artisan.page/13.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:flush`](https://artisan.page/13.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/13.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/13.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:monitor`](https://artisan.page/13.x/queuemonitor.md) — Monitor the size of the specified queues
+- [`php artisan queue:pause`](https://artisan.page/13.x/queuepause.md) — Pause job processing for a specific queue
+- [`php artisan queue:prune-batches`](https://artisan.page/13.x/queueprune-batches.md) — Prune stale entries from the batches database
+- [`php artisan queue:prune-failed`](https://artisan.page/13.x/queueprune-failed.md) — Prune stale entries from the failed jobs table
+- [`php artisan queue:restart`](https://artisan.page/13.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:resume`](https://artisan.page/13.x/queueresume.md) — Resume job processing for a paused queue
+- [`php artisan queue:retry`](https://artisan.page/13.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:retry-batch`](https://artisan.page/13.x/queueretry-batch.md) — Retry the failed jobs for a batch
+- [`php artisan queue:work`](https://artisan.page/13.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan reload`](https://artisan.page/13.x/reload.md) — Reload running services
+- [`php artisan reverb:install`](https://artisan.page/13.x/reverbinstall.md) — Install the Reverb dependencies
+- [`php artisan reverb:restart`](https://artisan.page/13.x/reverbrestart.md) — Restart the Reverb server
+- [`php artisan reverb:start`](https://artisan.page/13.x/reverbstart.md) — Start the Reverb server
+- [`php artisan roster:scan`](https://artisan.page/13.x/rosterscan.md) — Detect packages & approaches in use and output as JSON
+- [`php artisan route:cache`](https://artisan.page/13.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/13.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/13.x/routelist.md) — List all registered routes
+- [`php artisan sail:add`](https://artisan.page/13.x/sailadd.md) — Add a service to an existing Sail installation
+- [`php artisan sail:install`](https://artisan.page/13.x/sailinstall.md) — Install Laravel Sail's default Docker Compose file
+- [`php artisan sail:publish`](https://artisan.page/13.x/sailpublish.md) — Publish the Laravel Sail Docker files
+- [`php artisan sanctum:prune-expired`](https://artisan.page/13.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours
+- [`php artisan schedule:clear-cache`](https://artisan.page/13.x/scheduleclear-cache.md) — Delete the cached mutex files created by scheduler
+- [`php artisan schedule:finish`](https://artisan.page/13.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:interrupt`](https://artisan.page/13.x/scheduleinterrupt.md) — Interrupt the current schedule run
+- [`php artisan schedule:list`](https://artisan.page/13.x/schedulelist.md) — List all scheduled tasks
+- [`php artisan schedule:pause`](https://artisan.page/13.x/schedulepause.md) — Pause the scheduler
+- [`php artisan schedule:resume`](https://artisan.page/13.x/scheduleresume.md) — Resume the schedule
+- [`php artisan schedule:run`](https://artisan.page/13.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan schedule:test`](https://artisan.page/13.x/scheduletest.md) — Run a scheduled command
+- [`php artisan schedule:work`](https://artisan.page/13.x/schedulework.md) — Start the schedule worker
+- [`php artisan schema:dump`](https://artisan.page/13.x/schemadump.md) — Dump the given database schema
+- [`php artisan scout:delete-all-indexes`](https://artisan.page/13.x/scoutdelete-all-indexes.md) — Delete all indexes
+- [`php artisan scout:delete-index`](https://artisan.page/13.x/scoutdelete-index.md) — Delete an index
+- [`php artisan scout:flush`](https://artisan.page/13.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/13.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan scout:index`](https://artisan.page/13.x/scoutindex.md) — Create an index
+- [`php artisan scout:queue-import`](https://artisan.page/13.x/scoutqueue-import.md) — Import the given model into the search index via chunked, queued jobs
+- [`php artisan scout:sync-index-settings`](https://artisan.page/13.x/scoutsync-index-settings.md) — Sync your configured index settings with your search engine (Meilisearch)
+- [`php artisan serve`](https://artisan.page/13.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan spark:install`](https://artisan.page/13.x/sparkinstall.md) — Install all of the Spark resources
+- [`php artisan storage:link`](https://artisan.page/13.x/storagelink.md) — Create the symbolic links configured for the application
+- [`php artisan storage:unlink`](https://artisan.page/13.x/storageunlink.md) — Delete existing symbolic links configured for the application
+- [`php artisan stub:publish`](https://artisan.page/13.x/stubpublish.md) — Publish all stubs that are available for customization
+- [`php artisan telescope:clear`](https://artisan.page/13.x/telescopeclear.md) — Delete all Telescope data from storage
+- [`php artisan telescope:install`](https://artisan.page/13.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:pause`](https://artisan.page/13.x/telescopepause.md) — Pause all Telescope watchers
+- [`php artisan telescope:prune`](https://artisan.page/13.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/13.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan telescope:resume`](https://artisan.page/13.x/telescoperesume.md) — Unpause all Telescope watchers
+- [`php artisan test`](https://artisan.page/13.x/test.md) — Run the application tests
+- [`php artisan tinker`](https://artisan.page/13.x/tinker.md) — Interact with your application
+- [`php artisan up`](https://artisan.page/13.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vapor:handle`](https://artisan.page/13.x/vaporhandle.md)
+- [`php artisan vapor:health-check`](https://artisan.page/13.x/vaporhealth-check.md) — Check the health of the Vapor application
+- [`php artisan vapor:queue-failed`](https://artisan.page/13.x/vaporqueue-failed.md) — List all of the failed queue jobs
+- [`php artisan vapor:schedule`](https://artisan.page/13.x/vaporschedule.md) — Run the scheduled commands at the beginning of every minute
+- [`php artisan vapor:work`](https://artisan.page/13.x/vaporwork.md) — Process a Vapor job
+- [`php artisan vendor:publish`](https://artisan.page/13.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/13.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/13.x/viewclear.md) — Clear all compiled view files
+- [`php artisan volt:install`](https://artisan.page/13.x/voltinstall.md) — Install all of the Volt resources
 
-Note: Colons in command names are stripped in URLs. For example, `make:migration` becomes `makemigration`.
+## Laravel 12.x
 
-## Available Laravel Versions
+- [`php artisan _complete`](https://artisan.page/12.x/_complete.md) — Internal command to provide shell completion suggestions
+- [`php artisan about`](https://artisan.page/12.x/about.md) — Display basic information about your application
+- [`php artisan auth:clear-resets`](https://artisan.page/12.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan boost:add-skill`](https://artisan.page/12.x/boostadd-skill.md) — Add skills from a remote GitHub repository
+- [`php artisan boost:execute-tool`](https://artisan.page/12.x/boostexecute-tool.md) — Execute a Boost MCP tool in isolation (internal command)
+- [`php artisan boost:install`](https://artisan.page/12.x/boostinstall.md)
+- [`php artisan boost:list-skills`](https://artisan.page/12.x/boostlist-skills.md) — List all available skills in the current project
+- [`php artisan boost:mcp`](https://artisan.page/12.x/boostmcp.md) — Starts Laravel Boost (usually from mcp.json)
+- [`php artisan boost:update`](https://artisan.page/12.x/boostupdate.md) — Update the Laravel Boost guidelines & skills to the latest guidance
+- [`php artisan breeze:install`](https://artisan.page/12.x/breezeinstall.md) — Install the Breeze controllers and resources
+- [`php artisan cache:clear`](https://artisan.page/12.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/12.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:prune-stale-tags`](https://artisan.page/12.x/cacheprune-stale-tags.md) — Prune stale cache tags from the cache (Redis only)
+- [`php artisan cashier:webhook`](https://artisan.page/12.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier
+- [`php artisan channel:list`](https://artisan.page/12.x/channellist.md) — List all registered private broadcast channels
+- [`php artisan clear-compiled`](https://artisan.page/12.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan completion`](https://artisan.page/12.x/completion.md) — Dump the shell completion script
+- [`php artisan config:cache`](https://artisan.page/12.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/12.x/configclear.md) — Remove the configuration cache file
+- [`php artisan config:publish`](https://artisan.page/12.x/configpublish.md) — Publish configuration files to your application
+- [`php artisan config:show`](https://artisan.page/12.x/configshow.md) — Display all of the values for a given configuration file or key
+- [`php artisan db`](https://artisan.page/12.x/db.md) — Start a new database CLI session
+- [`php artisan db:monitor`](https://artisan.page/12.x/dbmonitor.md) — Monitor the number of connections on the specified database
+- [`php artisan db:seed`](https://artisan.page/12.x/dbseed.md) — Seed the database with records
+- [`php artisan db:show`](https://artisan.page/12.x/dbshow.md) — Display information about the given database
+- [`php artisan db:table`](https://artisan.page/12.x/dbtable.md) — Display information about the given database table
+- [`php artisan db:wipe`](https://artisan.page/12.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan docs`](https://artisan.page/12.x/docs.md) — Access the Laravel documentation
+- [`php artisan down`](https://artisan.page/12.x/down.md) — Put the application into maintenance / demo mode
+- [`php artisan dusk`](https://artisan.page/12.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/12.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/12.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/12.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/12.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/12.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/12.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/12.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/12.x/env.md) — Display the current framework environment
+- [`php artisan env:decrypt`](https://artisan.page/12.x/envdecrypt.md) — Decrypt an environment file
+- [`php artisan env:encrypt`](https://artisan.page/12.x/envencrypt.md) — Encrypt an environment file
+- [`php artisan event:cache`](https://artisan.page/12.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/12.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/12.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/12.x/eventlist.md) — List the application's events and listeners
+- [`php artisan fortify:install`](https://artisan.page/12.x/fortifyinstall.md) — Install all of the Fortify resources
+- [`php artisan help`](https://artisan.page/12.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/12.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:clear`](https://artisan.page/12.x/horizonclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan horizon:clear-metrics`](https://artisan.page/12.x/horizonclear-metrics.md) — Delete metrics for all jobs and queues
+- [`php artisan horizon:continue`](https://artisan.page/12.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:continue-supervisor`](https://artisan.page/12.x/horizoncontinue-supervisor.md) — Instruct the supervisor to continue processing jobs
+- [`php artisan horizon:forget`](https://artisan.page/12.x/horizonforget.md) — Delete a failed queue job
+- [`php artisan horizon:install`](https://artisan.page/12.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/12.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:listen`](https://artisan.page/12.x/horizonlisten.md) — Run Horizon and automatically restart workers on file changes
+- [`php artisan horizon:pause`](https://artisan.page/12.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:pause-supervisor`](https://artisan.page/12.x/horizonpause-supervisor.md) — Pause a supervisor
+- [`php artisan horizon:publish`](https://artisan.page/12.x/horizonpublish.md) — Publish all of the Horizon resources
+- [`php artisan horizon:purge`](https://artisan.page/12.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/12.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/12.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/12.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisor-status`](https://artisan.page/12.x/horizonsupervisor-status.md) — Show the status for a given supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/12.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/12.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/12.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/12.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:check-ssr`](https://artisan.page/12.x/inertiacheck-ssr.md) — Check the Inertia SSR server health status
+- [`php artisan inertia:middleware`](https://artisan.page/12.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inertia:start-ssr`](https://artisan.page/12.x/inertiastart-ssr.md) — Start the Inertia SSR server
+- [`php artisan inertia:stop-ssr`](https://artisan.page/12.x/inertiastop-ssr.md) — Stop the Inertia SSR server
+- [`php artisan inspire`](https://artisan.page/12.x/inspire.md) — Display an inspiring quote
+- [`php artisan install:api`](https://artisan.page/12.x/installapi.md) — Create an API routes file and install Laravel Sanctum or Laravel Passport
+- [`php artisan install:broadcasting`](https://artisan.page/12.x/installbroadcasting.md) — Create a broadcasting channel routes file
+- [`php artisan invoke-serialized-closure`](https://artisan.page/12.x/invoke-serialized-closure.md) — Invoke the given serialized closure
+- [`php artisan jetstream:install`](https://artisan.page/12.x/jetstreaminstall.md) — Install the Jetstream components and resources
+- [`php artisan key:generate`](https://artisan.page/12.x/keygenerate.md) — Set the application key
+- [`php artisan lang:publish`](https://artisan.page/12.x/langpublish.md) — Publish all language files that are available for customization
+- [`php artisan list`](https://artisan.page/12.x/list.md) — List commands
+- [`php artisan livewire:attribute`](https://artisan.page/12.x/livewireattribute.md) — Create a new Livewire attribute class
+- [`php artisan livewire:config`](https://artisan.page/12.x/livewireconfig.md) — Publish Livewire config file
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/12.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+- [`php artisan livewire:convert`](https://artisan.page/12.x/livewireconvert.md) — Convert a Livewire component between single-file and multi-file formats
+- [`php artisan livewire:form`](https://artisan.page/12.x/livewireform.md) — Create a new Livewire form class
+- [`php artisan livewire:layout`](https://artisan.page/12.x/livewirelayout.md) — Create a new app layout file
+- [`php artisan livewire:make`](https://artisan.page/12.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:publish`](https://artisan.page/12.x/livewirepublish.md) — Publish Livewire configuration
+- [`php artisan livewire:stubs`](https://artisan.page/12.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan make:cache-table`](https://artisan.page/12.x/makecache-table.md) — Create a migration for the cache database table
+- [`php artisan make:cast`](https://artisan.page/12.x/makecast.md) — Create a new custom Eloquent cast class
+- [`php artisan make:channel`](https://artisan.page/12.x/makechannel.md) — Create a new channel class
+- [`php artisan make:class`](https://artisan.page/12.x/makeclass.md) — Create a new class
+- [`php artisan make:command`](https://artisan.page/12.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:component`](https://artisan.page/12.x/makecomponent.md) — Create a new view component class
+- [`php artisan make:config`](https://artisan.page/12.x/makeconfig.md) — Create a new configuration file
+- [`php artisan make:controller`](https://artisan.page/12.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:enum`](https://artisan.page/12.x/makeenum.md) — Create a new enum
+- [`php artisan make:event`](https://artisan.page/12.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/12.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/12.x/makefactory.md) — Create a new model factory
+- [`php artisan make:interface`](https://artisan.page/12.x/makeinterface.md) — Create a new interface
+- [`php artisan make:job`](https://artisan.page/12.x/makejob.md) — Create a new job class
+- [`php artisan make:job-middleware`](https://artisan.page/12.x/makejob-middleware.md) — Create a new job middleware class
+- [`php artisan make:listener`](https://artisan.page/12.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/12.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/12.x/makemail.md) — Create a new email class
+- [`php artisan make:mcp-app-resource`](https://artisan.page/12.x/makemcp-app-resource.md) — Create a new MCP app resource class and linked view
+- [`php artisan make:mcp-prompt`](https://artisan.page/12.x/makemcp-prompt.md) — Create a new MCP prompt class
+- [`php artisan make:mcp-resource`](https://artisan.page/12.x/makemcp-resource.md) — Create a new MCP resource class
+- [`php artisan make:mcp-server`](https://artisan.page/12.x/makemcp-server.md) — Create a new MCP server class
+- [`php artisan make:mcp-tool`](https://artisan.page/12.x/makemcp-tool.md) — Create a new MCP tool class
+- [`php artisan make:middleware`](https://artisan.page/12.x/makemiddleware.md) — Create a new HTTP middleware class
+- [`php artisan make:migration`](https://artisan.page/12.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/12.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/12.x/makenotification.md) — Create a new notification class
+- [`php artisan make:notifications-table`](https://artisan.page/12.x/makenotifications-table.md) — Create a migration for the notifications table
+- [`php artisan make:observer`](https://artisan.page/12.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/12.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/12.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:queue-batches-table`](https://artisan.page/12.x/makequeue-batches-table.md) — Create a migration for the batches database table
+- [`php artisan make:queue-failed-table`](https://artisan.page/12.x/makequeue-failed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan make:queue-table`](https://artisan.page/12.x/makequeue-table.md) — Create a migration for the queue jobs database table
+- [`php artisan make:request`](https://artisan.page/12.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/12.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/12.x/makerule.md) — Create a new validation rule
+- [`php artisan make:scope`](https://artisan.page/12.x/makescope.md) — Create a new scope class
+- [`php artisan make:seeder`](https://artisan.page/12.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:session-table`](https://artisan.page/12.x/makesession-table.md) — Create a migration for the session database table
+- [`php artisan make:test`](https://artisan.page/12.x/maketest.md) — Create a new test class
+- [`php artisan make:trait`](https://artisan.page/12.x/maketrait.md) — Create a new trait
+- [`php artisan make:view`](https://artisan.page/12.x/makeview.md) — Create a new view
+- [`php artisan make:volt`](https://artisan.page/12.x/makevolt.md) — Create a new Volt component
+- [`php artisan mcp:inspector`](https://artisan.page/12.x/mcpinspector.md) — Open the MCP Inspector tool to debug and test MCP Servers
+- [`php artisan mcp:start`](https://artisan.page/12.x/mcpstart.md) — Start the MCP Server for a given handle
+- [`php artisan migrate`](https://artisan.page/12.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/12.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/12.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/12.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/12.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/12.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/12.x/migratestatus.md) — Show the status of each migration
+- [`php artisan model:prune`](https://artisan.page/12.x/modelprune.md) — Prune models that are no longer needed
+- [`php artisan model:show`](https://artisan.page/12.x/modelshow.md) — Show information about an Eloquent model
+- [`php artisan nightwatch:agent`](https://artisan.page/12.x/nightwatchagent.md) — Run the Nightwatch agent.
+- [`php artisan nightwatch:deploy`](https://artisan.page/12.x/nightwatchdeploy.md) — Send deployment metadata to Nightwatch.
+- [`php artisan nightwatch:status`](https://artisan.page/12.x/nightwatchstatus.md) — Get the current status of the Nightwatch agent.
+- [`php artisan nova:action`](https://artisan.page/12.x/novaaction.md) — Create a new action class
+- [`php artisan nova:asset`](https://artisan.page/12.x/novaasset.md) — Create a new asset
+- [`php artisan nova:base-resource`](https://artisan.page/12.x/novabase-resource.md) — Create a new base resource class
+- [`php artisan nova:card`](https://artisan.page/12.x/novacard.md) — Create a new card
+- [`php artisan nova:check-license`](https://artisan.page/12.x/novacheck-license.md) — Verify your Nova license key
+- [`php artisan nova:custom-filter`](https://artisan.page/12.x/novacustom-filter.md) — Create a new custom filter
+- [`php artisan nova:dashboard`](https://artisan.page/12.x/novadashboard.md) — Create a new dashboard.
+- [`php artisan nova:field`](https://artisan.page/12.x/novafield.md) — Create a new field
+- [`php artisan nova:filter`](https://artisan.page/12.x/novafilter.md) — Create a new filter class
+- [`php artisan nova:install`](https://artisan.page/12.x/novainstall.md) — Install all of the Nova resources
+- [`php artisan nova:lens`](https://artisan.page/12.x/novalens.md) — Create a new lens class
+- [`php artisan nova:partition`](https://artisan.page/12.x/novapartition.md) — Create a new metric (partition) class
+- [`php artisan nova:policy`](https://artisan.page/12.x/novapolicy.md) — Create a new policy class
+- [`php artisan nova:progress`](https://artisan.page/12.x/novaprogress.md) — Create a new metric (progress) class
+- [`php artisan nova:publish`](https://artisan.page/12.x/novapublish.md) — Publish all of the Nova resources
+- [`php artisan nova:repeatable`](https://artisan.page/12.x/novarepeatable.md) — Create a new repeatable class
+- [`php artisan nova:resource`](https://artisan.page/12.x/novaresource.md) — Create a new resource class
+- [`php artisan nova:resource-tool`](https://artisan.page/12.x/novaresource-tool.md) — Create a new resource tool
+- [`php artisan nova:stubs`](https://artisan.page/12.x/novastubs.md) — Publish all stubs that are available for customization
+- [`php artisan nova:table`](https://artisan.page/12.x/novatable.md) — Create a new metric (table) class
+- [`php artisan nova:tool`](https://artisan.page/12.x/novatool.md) — Create a new tool
+- [`php artisan nova:translate`](https://artisan.page/12.x/novatranslate.md) — Create translation files for Nova
+- [`php artisan nova:trend`](https://artisan.page/12.x/novatrend.md) — Create a new metric (trend) class
+- [`php artisan nova:user`](https://artisan.page/12.x/novauser.md) — Create a new user
+- [`php artisan nova:value`](https://artisan.page/12.x/novavalue.md) — Create a new metric (single value) class
+- [`php artisan octane:frankenphp`](https://artisan.page/12.x/octanefrankenphp.md) — Start the Octane FrankenPHP server
+- [`php artisan octane:install`](https://artisan.page/12.x/octaneinstall.md) — Install the Octane components and resources
+- [`php artisan octane:reload`](https://artisan.page/12.x/octanereload.md) — Reload the Octane workers
+- [`php artisan octane:roadrunner`](https://artisan.page/12.x/octaneroadrunner.md) — Start the Octane RoadRunner server
+- [`php artisan octane:start`](https://artisan.page/12.x/octanestart.md) — Start the Octane server
+- [`php artisan octane:status`](https://artisan.page/12.x/octanestatus.md) — Get the current status of the Octane server
+- [`php artisan octane:stop`](https://artisan.page/12.x/octanestop.md) — Stop the Octane server
+- [`php artisan octane:swoole`](https://artisan.page/12.x/octaneswoole.md) — Start the Octane Swoole server
+- [`php artisan optimize`](https://artisan.page/12.x/optimize.md) — Cache framework bootstrap, configuration, and metadata to increase performance
+- [`php artisan optimize:clear`](https://artisan.page/12.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/12.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan pail`](https://artisan.page/12.x/pail.md) — Tails the application logs
+- [`php artisan passport:client`](https://artisan.page/12.x/passportclient.md) — Create a client for issuing access tokens
+- [`php artisan passport:hash`](https://artisan.page/12.x/passporthash.md) — Hash all of the existing secrets in the clients table
+- [`php artisan passport:install`](https://artisan.page/12.x/passportinstall.md) — Run the commands necessary to prepare Passport for use
+- [`php artisan passport:keys`](https://artisan.page/12.x/passportkeys.md) — Create the encryption keys for API authentication
+- [`php artisan passport:purge`](https://artisan.page/12.x/passportpurge.md) — Purge revoked and / or expired tokens and authentication codes
+- [`php artisan pennant:feature`](https://artisan.page/12.x/pennantfeature.md) — Create a new feature class
+- [`php artisan pennant:purge`](https://artisan.page/12.x/pennantpurge.md) — Delete Pennant features from storage
+- [`php artisan pulse:check`](https://artisan.page/12.x/pulsecheck.md) — Take a snapshot of the current server's pulse
+- [`php artisan pulse:clear`](https://artisan.page/12.x/pulseclear.md) — Delete all Pulse data from storage
+- [`php artisan pulse:restart`](https://artisan.page/12.x/pulserestart.md) — Restart any running "work" and "check" commands
+- [`php artisan pulse:work`](https://artisan.page/12.x/pulsework.md) — Process incoming Pulse data from the ingest stream
+- [`php artisan queue:clear`](https://artisan.page/12.x/queueclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan queue:failed`](https://artisan.page/12.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:flush`](https://artisan.page/12.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/12.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/12.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:monitor`](https://artisan.page/12.x/queuemonitor.md) — Monitor the size of the specified queues
+- [`php artisan queue:pause`](https://artisan.page/12.x/queuepause.md) — Pause job processing for a specific queue
+- [`php artisan queue:prune-batches`](https://artisan.page/12.x/queueprune-batches.md) — Prune stale entries from the batches database
+- [`php artisan queue:prune-failed`](https://artisan.page/12.x/queueprune-failed.md) — Prune stale entries from the failed jobs table
+- [`php artisan queue:restart`](https://artisan.page/12.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:resume`](https://artisan.page/12.x/queueresume.md) — Resume job processing for a paused queue
+- [`php artisan queue:retry`](https://artisan.page/12.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:retry-batch`](https://artisan.page/12.x/queueretry-batch.md) — Retry the failed jobs for a batch
+- [`php artisan queue:work`](https://artisan.page/12.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan reload`](https://artisan.page/12.x/reload.md) — Reload running services
+- [`php artisan reverb:install`](https://artisan.page/12.x/reverbinstall.md) — Install the Reverb dependencies
+- [`php artisan reverb:restart`](https://artisan.page/12.x/reverbrestart.md) — Restart the Reverb server
+- [`php artisan reverb:start`](https://artisan.page/12.x/reverbstart.md) — Start the Reverb server
+- [`php artisan roster:scan`](https://artisan.page/12.x/rosterscan.md) — Detect packages & approaches in use and output as JSON
+- [`php artisan route:cache`](https://artisan.page/12.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/12.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/12.x/routelist.md) — List all registered routes
+- [`php artisan sail:add`](https://artisan.page/12.x/sailadd.md) — Add a service to an existing Sail installation
+- [`php artisan sail:install`](https://artisan.page/12.x/sailinstall.md) — Install Laravel Sail's default Docker Compose file
+- [`php artisan sail:publish`](https://artisan.page/12.x/sailpublish.md) — Publish the Laravel Sail Docker files
+- [`php artisan sanctum:prune-expired`](https://artisan.page/12.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours
+- [`php artisan schedule:clear-cache`](https://artisan.page/12.x/scheduleclear-cache.md) — Delete the cached mutex files created by scheduler
+- [`php artisan schedule:finish`](https://artisan.page/12.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:interrupt`](https://artisan.page/12.x/scheduleinterrupt.md) — Interrupt the current schedule run
+- [`php artisan schedule:list`](https://artisan.page/12.x/schedulelist.md) — List all scheduled tasks
+- [`php artisan schedule:run`](https://artisan.page/12.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan schedule:test`](https://artisan.page/12.x/scheduletest.md) — Run a scheduled command
+- [`php artisan schedule:work`](https://artisan.page/12.x/schedulework.md) — Start the schedule worker
+- [`php artisan schema:dump`](https://artisan.page/12.x/schemadump.md) — Dump the given database schema
+- [`php artisan scout:delete-all-indexes`](https://artisan.page/12.x/scoutdelete-all-indexes.md) — Delete all indexes
+- [`php artisan scout:delete-index`](https://artisan.page/12.x/scoutdelete-index.md) — Delete an index
+- [`php artisan scout:flush`](https://artisan.page/12.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/12.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan scout:index`](https://artisan.page/12.x/scoutindex.md) — Create an index
+- [`php artisan scout:queue-import`](https://artisan.page/12.x/scoutqueue-import.md) — Import the given model into the search index via chunked, queued jobs
+- [`php artisan scout:sync-index-settings`](https://artisan.page/12.x/scoutsync-index-settings.md) — Sync your configured index settings with your search engine (Meilisearch)
+- [`php artisan serve`](https://artisan.page/12.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan spark:install`](https://artisan.page/12.x/sparkinstall.md) — Install all of the Spark resources
+- [`php artisan storage:link`](https://artisan.page/12.x/storagelink.md) — Create the symbolic links configured for the application
+- [`php artisan storage:unlink`](https://artisan.page/12.x/storageunlink.md) — Delete existing symbolic links configured for the application
+- [`php artisan stub:publish`](https://artisan.page/12.x/stubpublish.md) — Publish all stubs that are available for customization
+- [`php artisan telescope:clear`](https://artisan.page/12.x/telescopeclear.md) — Delete all Telescope data from storage
+- [`php artisan telescope:install`](https://artisan.page/12.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:pause`](https://artisan.page/12.x/telescopepause.md) — Pause all Telescope watchers
+- [`php artisan telescope:prune`](https://artisan.page/12.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/12.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan telescope:resume`](https://artisan.page/12.x/telescoperesume.md) — Unpause all Telescope watchers
+- [`php artisan test`](https://artisan.page/12.x/test.md) — Run the application tests
+- [`php artisan tinker`](https://artisan.page/12.x/tinker.md) — Interact with your application
+- [`php artisan up`](https://artisan.page/12.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vapor:handle`](https://artisan.page/12.x/vaporhandle.md)
+- [`php artisan vapor:health-check`](https://artisan.page/12.x/vaporhealth-check.md) — Check the health of the Vapor application
+- [`php artisan vapor:queue-failed`](https://artisan.page/12.x/vaporqueue-failed.md) — List all of the failed queue jobs
+- [`php artisan vapor:schedule`](https://artisan.page/12.x/vaporschedule.md) — Run the scheduled commands at the beginning of every minute
+- [`php artisan vapor:work`](https://artisan.page/12.x/vaporwork.md) — Process a Vapor job
+- [`php artisan vendor:publish`](https://artisan.page/12.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/12.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/12.x/viewclear.md) — Clear all compiled view files
+- [`php artisan volt:install`](https://artisan.page/12.x/voltinstall.md) — Install all of the Volt resources
 
-- 13.x (latest)
-- 12.x
-- 11.x
-- 10.x
-- 9.x
-- 8.x
-- 7.x
-- 6.x
-- 5.x
+## Laravel 11.x
 
-## API Endpoints
+- [`php artisan _complete`](https://artisan.page/11.x/_complete.md) — Internal command to provide shell completion suggestions
+- [`php artisan about`](https://artisan.page/11.x/about.md) — Display basic information about your application
+- [`php artisan auth:clear-resets`](https://artisan.page/11.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan boost:add-skill`](https://artisan.page/11.x/boostadd-skill.md) — Add skills from a remote GitHub repository
+- [`php artisan boost:execute-tool`](https://artisan.page/11.x/boostexecute-tool.md) — Execute a Boost MCP tool in isolation (internal command)
+- [`php artisan boost:install`](https://artisan.page/11.x/boostinstall.md)
+- [`php artisan boost:list-skills`](https://artisan.page/11.x/boostlist-skills.md) — List all available skills in the current project
+- [`php artisan boost:mcp`](https://artisan.page/11.x/boostmcp.md) — Starts Laravel Boost (usually from mcp.json)
+- [`php artisan boost:update`](https://artisan.page/11.x/boostupdate.md) — Update the Laravel Boost guidelines & skills to the latest guidance
+- [`php artisan breeze:install`](https://artisan.page/11.x/breezeinstall.md) — Install the Breeze controllers and resources
+- [`php artisan cache:clear`](https://artisan.page/11.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/11.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:prune-stale-tags`](https://artisan.page/11.x/cacheprune-stale-tags.md) — Prune stale cache tags from the cache (Redis only)
+- [`php artisan cashier:webhook`](https://artisan.page/11.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier
+- [`php artisan channel:list`](https://artisan.page/11.x/channellist.md) — List all registered private broadcast channels
+- [`php artisan clear-compiled`](https://artisan.page/11.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan completion`](https://artisan.page/11.x/completion.md) — Dump the shell completion script
+- [`php artisan config:cache`](https://artisan.page/11.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/11.x/configclear.md) — Remove the configuration cache file
+- [`php artisan config:publish`](https://artisan.page/11.x/configpublish.md) — Publish configuration files to your application
+- [`php artisan config:show`](https://artisan.page/11.x/configshow.md) — Display all of the values for a given configuration file or key
+- [`php artisan db`](https://artisan.page/11.x/db.md) — Start a new database CLI session
+- [`php artisan db:monitor`](https://artisan.page/11.x/dbmonitor.md) — Monitor the number of connections on the specified database
+- [`php artisan db:seed`](https://artisan.page/11.x/dbseed.md) — Seed the database with records
+- [`php artisan db:show`](https://artisan.page/11.x/dbshow.md) — Display information about the given database
+- [`php artisan db:table`](https://artisan.page/11.x/dbtable.md) — Display information about the given database table
+- [`php artisan db:wipe`](https://artisan.page/11.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan docs`](https://artisan.page/11.x/docs.md) — Access the Laravel documentation
+- [`php artisan down`](https://artisan.page/11.x/down.md) — Put the application into maintenance / demo mode
+- [`php artisan dusk`](https://artisan.page/11.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/11.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/11.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/11.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/11.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/11.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/11.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/11.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/11.x/env.md) — Display the current framework environment
+- [`php artisan env:decrypt`](https://artisan.page/11.x/envdecrypt.md) — Decrypt an environment file
+- [`php artisan env:encrypt`](https://artisan.page/11.x/envencrypt.md) — Encrypt an environment file
+- [`php artisan event:cache`](https://artisan.page/11.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/11.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/11.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/11.x/eventlist.md) — List the application's events and listeners
+- [`php artisan fortify:install`](https://artisan.page/11.x/fortifyinstall.md) — Install all of the Fortify resources
+- [`php artisan help`](https://artisan.page/11.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/11.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:clear`](https://artisan.page/11.x/horizonclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan horizon:clear-metrics`](https://artisan.page/11.x/horizonclear-metrics.md) — Delete metrics for all jobs and queues
+- [`php artisan horizon:continue`](https://artisan.page/11.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:continue-supervisor`](https://artisan.page/11.x/horizoncontinue-supervisor.md) — Instruct the supervisor to continue processing jobs
+- [`php artisan horizon:forget`](https://artisan.page/11.x/horizonforget.md) — Delete a failed queue job
+- [`php artisan horizon:install`](https://artisan.page/11.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/11.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:listen`](https://artisan.page/11.x/horizonlisten.md) — Run Horizon and automatically restart workers on file changes
+- [`php artisan horizon:pause`](https://artisan.page/11.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:pause-supervisor`](https://artisan.page/11.x/horizonpause-supervisor.md) — Pause a supervisor
+- [`php artisan horizon:publish`](https://artisan.page/11.x/horizonpublish.md) — Publish all of the Horizon resources
+- [`php artisan horizon:purge`](https://artisan.page/11.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/11.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/11.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/11.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisor-status`](https://artisan.page/11.x/horizonsupervisor-status.md) — Show the status for a given supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/11.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/11.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/11.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/11.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:check-ssr`](https://artisan.page/11.x/inertiacheck-ssr.md) — Check the Inertia SSR server health status
+- [`php artisan inertia:middleware`](https://artisan.page/11.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inertia:start-ssr`](https://artisan.page/11.x/inertiastart-ssr.md) — Start the Inertia SSR server
+- [`php artisan inertia:stop-ssr`](https://artisan.page/11.x/inertiastop-ssr.md) — Stop the Inertia SSR server
+- [`php artisan inspire`](https://artisan.page/11.x/inspire.md) — Display an inspiring quote
+- [`php artisan install:api`](https://artisan.page/11.x/installapi.md) — Create an API routes file and install Laravel Sanctum or Laravel Passport
+- [`php artisan install:broadcasting`](https://artisan.page/11.x/installbroadcasting.md) — Create a broadcasting channel routes file
+- [`php artisan invoke-serialized-closure`](https://artisan.page/11.x/invoke-serialized-closure.md) — Invoke the given serialized closure
+- [`php artisan jetstream:install`](https://artisan.page/11.x/jetstreaminstall.md) — Install the Jetstream components and resources
+- [`php artisan key:generate`](https://artisan.page/11.x/keygenerate.md) — Set the application key
+- [`php artisan lang:publish`](https://artisan.page/11.x/langpublish.md) — Publish all language files that are available for customization
+- [`php artisan list`](https://artisan.page/11.x/list.md) — List commands
+- [`php artisan livewire:attribute`](https://artisan.page/11.x/livewireattribute.md) — Create a new Livewire attribute class
+- [`php artisan livewire:config`](https://artisan.page/11.x/livewireconfig.md) — Publish Livewire config file
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/11.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+- [`php artisan livewire:convert`](https://artisan.page/11.x/livewireconvert.md) — Convert a Livewire component between single-file and multi-file formats
+- [`php artisan livewire:form`](https://artisan.page/11.x/livewireform.md) — Create a new Livewire form class
+- [`php artisan livewire:layout`](https://artisan.page/11.x/livewirelayout.md) — Create a new app layout file
+- [`php artisan livewire:make`](https://artisan.page/11.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:publish`](https://artisan.page/11.x/livewirepublish.md) — Publish Livewire configuration
+- [`php artisan livewire:stubs`](https://artisan.page/11.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan make:cache-table`](https://artisan.page/11.x/makecache-table.md) — Create a migration for the cache database table
+- [`php artisan make:cast`](https://artisan.page/11.x/makecast.md) — Create a new custom Eloquent cast class
+- [`php artisan make:channel`](https://artisan.page/11.x/makechannel.md) — Create a new channel class
+- [`php artisan make:class`](https://artisan.page/11.x/makeclass.md) — Create a new class
+- [`php artisan make:command`](https://artisan.page/11.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:component`](https://artisan.page/11.x/makecomponent.md) — Create a new view component class
+- [`php artisan make:controller`](https://artisan.page/11.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:enum`](https://artisan.page/11.x/makeenum.md) — Create a new enum
+- [`php artisan make:event`](https://artisan.page/11.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/11.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/11.x/makefactory.md) — Create a new model factory
+- [`php artisan make:interface`](https://artisan.page/11.x/makeinterface.md) — Create a new interface
+- [`php artisan make:job`](https://artisan.page/11.x/makejob.md) — Create a new job class
+- [`php artisan make:job-middleware`](https://artisan.page/11.x/makejob-middleware.md) — Create a new job middleware class
+- [`php artisan make:listener`](https://artisan.page/11.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/11.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/11.x/makemail.md) — Create a new email class
+- [`php artisan make:mcp-app-resource`](https://artisan.page/11.x/makemcp-app-resource.md) — Create a new MCP app resource class and linked view
+- [`php artisan make:mcp-prompt`](https://artisan.page/11.x/makemcp-prompt.md) — Create a new MCP prompt class
+- [`php artisan make:mcp-resource`](https://artisan.page/11.x/makemcp-resource.md) — Create a new MCP resource class
+- [`php artisan make:mcp-server`](https://artisan.page/11.x/makemcp-server.md) — Create a new MCP server class
+- [`php artisan make:mcp-tool`](https://artisan.page/11.x/makemcp-tool.md) — Create a new MCP tool class
+- [`php artisan make:middleware`](https://artisan.page/11.x/makemiddleware.md) — Create a new HTTP middleware class
+- [`php artisan make:migration`](https://artisan.page/11.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/11.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/11.x/makenotification.md) — Create a new notification class
+- [`php artisan make:notifications-table`](https://artisan.page/11.x/makenotifications-table.md) — Create a migration for the notifications table
+- [`php artisan make:observer`](https://artisan.page/11.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/11.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/11.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:queue-batches-table`](https://artisan.page/11.x/makequeue-batches-table.md) — Create a migration for the batches database table
+- [`php artisan make:queue-failed-table`](https://artisan.page/11.x/makequeue-failed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan make:queue-table`](https://artisan.page/11.x/makequeue-table.md) — Create a migration for the queue jobs database table
+- [`php artisan make:request`](https://artisan.page/11.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/11.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/11.x/makerule.md) — Create a new validation rule
+- [`php artisan make:scope`](https://artisan.page/11.x/makescope.md) — Create a new scope class
+- [`php artisan make:seeder`](https://artisan.page/11.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:session-table`](https://artisan.page/11.x/makesession-table.md) — Create a migration for the session database table
+- [`php artisan make:test`](https://artisan.page/11.x/maketest.md) — Create a new test class
+- [`php artisan make:trait`](https://artisan.page/11.x/maketrait.md) — Create a new trait
+- [`php artisan make:view`](https://artisan.page/11.x/makeview.md) — Create a new view
+- [`php artisan make:volt`](https://artisan.page/11.x/makevolt.md) — Create a new Volt component
+- [`php artisan mcp:inspector`](https://artisan.page/11.x/mcpinspector.md) — Open the MCP Inspector tool to debug and test MCP Servers
+- [`php artisan mcp:start`](https://artisan.page/11.x/mcpstart.md) — Start the MCP Server for a given handle
+- [`php artisan migrate`](https://artisan.page/11.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/11.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/11.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/11.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/11.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/11.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/11.x/migratestatus.md) — Show the status of each migration
+- [`php artisan model:prune`](https://artisan.page/11.x/modelprune.md) — Prune models that are no longer needed
+- [`php artisan model:show`](https://artisan.page/11.x/modelshow.md) — Show information about an Eloquent model
+- [`php artisan nightwatch:agent`](https://artisan.page/11.x/nightwatchagent.md) — Run the Nightwatch agent.
+- [`php artisan nightwatch:deploy`](https://artisan.page/11.x/nightwatchdeploy.md) — Send deployment metadata to Nightwatch.
+- [`php artisan nightwatch:status`](https://artisan.page/11.x/nightwatchstatus.md) — Get the current status of the Nightwatch agent.
+- [`php artisan nova:action`](https://artisan.page/11.x/novaaction.md) — Create a new action class
+- [`php artisan nova:asset`](https://artisan.page/11.x/novaasset.md) — Create a new asset
+- [`php artisan nova:base-resource`](https://artisan.page/11.x/novabase-resource.md) — Create a new base resource class
+- [`php artisan nova:card`](https://artisan.page/11.x/novacard.md) — Create a new card
+- [`php artisan nova:check-license`](https://artisan.page/11.x/novacheck-license.md) — Verify your Nova license key
+- [`php artisan nova:custom-filter`](https://artisan.page/11.x/novacustom-filter.md) — Create a new custom filter
+- [`php artisan nova:dashboard`](https://artisan.page/11.x/novadashboard.md) — Create a new dashboard.
+- [`php artisan nova:field`](https://artisan.page/11.x/novafield.md) — Create a new field
+- [`php artisan nova:filter`](https://artisan.page/11.x/novafilter.md) — Create a new filter class
+- [`php artisan nova:install`](https://artisan.page/11.x/novainstall.md) — Install all of the Nova resources
+- [`php artisan nova:lens`](https://artisan.page/11.x/novalens.md) — Create a new lens class
+- [`php artisan nova:partition`](https://artisan.page/11.x/novapartition.md) — Create a new metric (partition) class
+- [`php artisan nova:policy`](https://artisan.page/11.x/novapolicy.md) — Create a new policy class
+- [`php artisan nova:progress`](https://artisan.page/11.x/novaprogress.md) — Create a new metric (progress) class
+- [`php artisan nova:publish`](https://artisan.page/11.x/novapublish.md) — Publish all of the Nova resources
+- [`php artisan nova:repeatable`](https://artisan.page/11.x/novarepeatable.md) — Create a new repeatable class
+- [`php artisan nova:resource`](https://artisan.page/11.x/novaresource.md) — Create a new resource class
+- [`php artisan nova:resource-tool`](https://artisan.page/11.x/novaresource-tool.md) — Create a new resource tool
+- [`php artisan nova:stubs`](https://artisan.page/11.x/novastubs.md) — Publish all stubs that are available for customization
+- [`php artisan nova:table`](https://artisan.page/11.x/novatable.md) — Create a new metric (table) class
+- [`php artisan nova:tool`](https://artisan.page/11.x/novatool.md) — Create a new tool
+- [`php artisan nova:translate`](https://artisan.page/11.x/novatranslate.md) — Create translation files for Nova
+- [`php artisan nova:trend`](https://artisan.page/11.x/novatrend.md) — Create a new metric (trend) class
+- [`php artisan nova:user`](https://artisan.page/11.x/novauser.md) — Create a new user
+- [`php artisan nova:value`](https://artisan.page/11.x/novavalue.md) — Create a new metric (single value) class
+- [`php artisan octane:frankenphp`](https://artisan.page/11.x/octanefrankenphp.md) — Start the Octane FrankenPHP server
+- [`php artisan octane:install`](https://artisan.page/11.x/octaneinstall.md) — Install the Octane components and resources
+- [`php artisan octane:reload`](https://artisan.page/11.x/octanereload.md) — Reload the Octane workers
+- [`php artisan octane:roadrunner`](https://artisan.page/11.x/octaneroadrunner.md) — Start the Octane RoadRunner server
+- [`php artisan octane:start`](https://artisan.page/11.x/octanestart.md) — Start the Octane server
+- [`php artisan octane:status`](https://artisan.page/11.x/octanestatus.md) — Get the current status of the Octane server
+- [`php artisan octane:stop`](https://artisan.page/11.x/octanestop.md) — Stop the Octane server
+- [`php artisan octane:swoole`](https://artisan.page/11.x/octaneswoole.md) — Start the Octane Swoole server
+- [`php artisan optimize`](https://artisan.page/11.x/optimize.md) — Cache framework bootstrap, configuration, and metadata to increase performance
+- [`php artisan optimize:clear`](https://artisan.page/11.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/11.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan pail`](https://artisan.page/11.x/pail.md) — Tails the application logs
+- [`php artisan passport:client`](https://artisan.page/11.x/passportclient.md) — Create a client for issuing access tokens
+- [`php artisan passport:hash`](https://artisan.page/11.x/passporthash.md) — Hash all of the existing secrets in the clients table
+- [`php artisan passport:install`](https://artisan.page/11.x/passportinstall.md) — Run the commands necessary to prepare Passport for use
+- [`php artisan passport:keys`](https://artisan.page/11.x/passportkeys.md) — Create the encryption keys for API authentication
+- [`php artisan passport:purge`](https://artisan.page/11.x/passportpurge.md) — Purge revoked and / or expired tokens and authentication codes
+- [`php artisan pennant:feature`](https://artisan.page/11.x/pennantfeature.md) — Create a new feature class
+- [`php artisan pennant:purge`](https://artisan.page/11.x/pennantpurge.md) — Delete Pennant features from storage
+- [`php artisan pulse:check`](https://artisan.page/11.x/pulsecheck.md) — Take a snapshot of the current server's pulse
+- [`php artisan pulse:clear`](https://artisan.page/11.x/pulseclear.md) — Delete all Pulse data from storage
+- [`php artisan pulse:restart`](https://artisan.page/11.x/pulserestart.md) — Restart any running "work" and "check" commands
+- [`php artisan pulse:work`](https://artisan.page/11.x/pulsework.md) — Process incoming Pulse data from the ingest stream
+- [`php artisan queue:clear`](https://artisan.page/11.x/queueclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan queue:failed`](https://artisan.page/11.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:flush`](https://artisan.page/11.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/11.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/11.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:monitor`](https://artisan.page/11.x/queuemonitor.md) — Monitor the size of the specified queues
+- [`php artisan queue:prune-batches`](https://artisan.page/11.x/queueprune-batches.md) — Prune stale entries from the batches database
+- [`php artisan queue:prune-failed`](https://artisan.page/11.x/queueprune-failed.md) — Prune stale entries from the failed jobs table
+- [`php artisan queue:restart`](https://artisan.page/11.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:retry`](https://artisan.page/11.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:retry-batch`](https://artisan.page/11.x/queueretry-batch.md) — Retry the failed jobs for a batch
+- [`php artisan queue:work`](https://artisan.page/11.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan reverb:install`](https://artisan.page/11.x/reverbinstall.md) — Install the Reverb dependencies
+- [`php artisan reverb:restart`](https://artisan.page/11.x/reverbrestart.md) — Restart the Reverb server
+- [`php artisan reverb:start`](https://artisan.page/11.x/reverbstart.md) — Start the Reverb server
+- [`php artisan roster:scan`](https://artisan.page/11.x/rosterscan.md) — Detect packages & approaches in use and output as JSON
+- [`php artisan route:cache`](https://artisan.page/11.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/11.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/11.x/routelist.md) — List all registered routes
+- [`php artisan sail:add`](https://artisan.page/11.x/sailadd.md) — Add a service to an existing Sail installation
+- [`php artisan sail:install`](https://artisan.page/11.x/sailinstall.md) — Install Laravel Sail's default Docker Compose file
+- [`php artisan sail:publish`](https://artisan.page/11.x/sailpublish.md) — Publish the Laravel Sail Docker files
+- [`php artisan sanctum:prune-expired`](https://artisan.page/11.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours
+- [`php artisan schedule:clear-cache`](https://artisan.page/11.x/scheduleclear-cache.md) — Delete the cached mutex files created by scheduler
+- [`php artisan schedule:finish`](https://artisan.page/11.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:interrupt`](https://artisan.page/11.x/scheduleinterrupt.md) — Interrupt the current schedule run
+- [`php artisan schedule:list`](https://artisan.page/11.x/schedulelist.md) — List all scheduled tasks
+- [`php artisan schedule:run`](https://artisan.page/11.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan schedule:test`](https://artisan.page/11.x/scheduletest.md) — Run a scheduled command
+- [`php artisan schedule:work`](https://artisan.page/11.x/schedulework.md) — Start the schedule worker
+- [`php artisan schema:dump`](https://artisan.page/11.x/schemadump.md) — Dump the given database schema
+- [`php artisan scout:delete-all-indexes`](https://artisan.page/11.x/scoutdelete-all-indexes.md) — Delete all indexes
+- [`php artisan scout:delete-index`](https://artisan.page/11.x/scoutdelete-index.md) — Delete an index
+- [`php artisan scout:flush`](https://artisan.page/11.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/11.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan scout:index`](https://artisan.page/11.x/scoutindex.md) — Create an index
+- [`php artisan scout:queue-import`](https://artisan.page/11.x/scoutqueue-import.md) — Import the given model into the search index via chunked, queued jobs
+- [`php artisan scout:sync-index-settings`](https://artisan.page/11.x/scoutsync-index-settings.md) — Sync your configured index settings with your search engine (Meilisearch)
+- [`php artisan serve`](https://artisan.page/11.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan spark:install`](https://artisan.page/11.x/sparkinstall.md) — Install all of the Spark resources
+- [`php artisan storage:link`](https://artisan.page/11.x/storagelink.md) — Create the symbolic links configured for the application
+- [`php artisan storage:unlink`](https://artisan.page/11.x/storageunlink.md) — Delete existing symbolic links configured for the application
+- [`php artisan stub:publish`](https://artisan.page/11.x/stubpublish.md) — Publish all stubs that are available for customization
+- [`php artisan telescope:clear`](https://artisan.page/11.x/telescopeclear.md) — Delete all Telescope data from storage
+- [`php artisan telescope:install`](https://artisan.page/11.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:pause`](https://artisan.page/11.x/telescopepause.md) — Pause all Telescope watchers
+- [`php artisan telescope:prune`](https://artisan.page/11.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/11.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan telescope:resume`](https://artisan.page/11.x/telescoperesume.md) — Unpause all Telescope watchers
+- [`php artisan test`](https://artisan.page/11.x/test.md) — Run the application tests
+- [`php artisan tinker`](https://artisan.page/11.x/tinker.md) — Interact with your application
+- [`php artisan up`](https://artisan.page/11.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vapor:handle`](https://artisan.page/11.x/vaporhandle.md)
+- [`php artisan vapor:health-check`](https://artisan.page/11.x/vaporhealth-check.md) — Check the health of the Vapor application
+- [`php artisan vapor:queue-failed`](https://artisan.page/11.x/vaporqueue-failed.md) — List all of the failed queue jobs
+- [`php artisan vapor:schedule`](https://artisan.page/11.x/vaporschedule.md) — Run the scheduled commands at the beginning of every minute
+- [`php artisan vapor:work`](https://artisan.page/11.x/vaporwork.md) — Process a Vapor job
+- [`php artisan vendor:publish`](https://artisan.page/11.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/11.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/11.x/viewclear.md) — Clear all compiled view files
+- [`php artisan volt:install`](https://artisan.page/11.x/voltinstall.md) — Install all of the Volt resources
 
-- `GET /api/versions` — Returns a JSON array of supported Laravel versions.
-- `GET /api/{version}` — Returns a JSON array of all commands for a given Laravel version. Use `latest` as an alias for the most recent version.
-- `GET /api/packages` — Returns a JSON array of Laravel package names.
+## Laravel 10.x
 
-## Sitemap
+- [`php artisan _complete`](https://artisan.page/10.x/_complete.md) — Internal command to provide shell completion suggestions
+- [`php artisan about`](https://artisan.page/10.x/about.md) — Display basic information about your application
+- [`php artisan auth:clear-resets`](https://artisan.page/10.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan breeze:install`](https://artisan.page/10.x/breezeinstall.md) — Install the Breeze controllers and resources
+- [`php artisan cache:clear`](https://artisan.page/10.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/10.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:prune-stale-tags`](https://artisan.page/10.x/cacheprune-stale-tags.md) — Prune stale cache tags from the cache (Redis only)
+- [`php artisan cache:table`](https://artisan.page/10.x/cachetable.md) — Create a migration for the cache database table
+- [`php artisan cashier:webhook`](https://artisan.page/10.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier
+- [`php artisan channel:list`](https://artisan.page/10.x/channellist.md) — List all registered private broadcast channels
+- [`php artisan clear-compiled`](https://artisan.page/10.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan completion`](https://artisan.page/10.x/completion.md) — Dump the shell completion script
+- [`php artisan config:cache`](https://artisan.page/10.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/10.x/configclear.md) — Remove the configuration cache file
+- [`php artisan config:show`](https://artisan.page/10.x/configshow.md) — Display all of the values for a given configuration file
+- [`php artisan db`](https://artisan.page/10.x/db.md) — Start a new database CLI session
+- [`php artisan db:monitor`](https://artisan.page/10.x/dbmonitor.md) — Monitor the number of connections on the specified database
+- [`php artisan db:seed`](https://artisan.page/10.x/dbseed.md) — Seed the database with records
+- [`php artisan db:show`](https://artisan.page/10.x/dbshow.md) — Display information about the given database
+- [`php artisan db:table`](https://artisan.page/10.x/dbtable.md) — Display information about the given database table
+- [`php artisan db:wipe`](https://artisan.page/10.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan docs`](https://artisan.page/10.x/docs.md) — Access the Laravel documentation
+- [`php artisan down`](https://artisan.page/10.x/down.md) — Put the application into maintenance / demo mode
+- [`php artisan dusk`](https://artisan.page/10.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/10.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/10.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/10.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/10.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/10.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/10.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/10.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/10.x/env.md) — Display the current framework environment
+- [`php artisan env:decrypt`](https://artisan.page/10.x/envdecrypt.md) — Decrypt an environment file
+- [`php artisan env:encrypt`](https://artisan.page/10.x/envencrypt.md) — Encrypt an environment file
+- [`php artisan event:cache`](https://artisan.page/10.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/10.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/10.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/10.x/eventlist.md) — List the application's events and listeners
+- [`php artisan fortify:install`](https://artisan.page/10.x/fortifyinstall.md) — Install all of the Fortify resources
+- [`php artisan help`](https://artisan.page/10.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/10.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:clear`](https://artisan.page/10.x/horizonclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan horizon:clear-metrics`](https://artisan.page/10.x/horizonclear-metrics.md) — Delete metrics for all jobs and queues
+- [`php artisan horizon:continue`](https://artisan.page/10.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:continue-supervisor`](https://artisan.page/10.x/horizoncontinue-supervisor.md) — Instruct the supervisor to continue processing jobs
+- [`php artisan horizon:forget`](https://artisan.page/10.x/horizonforget.md) — Delete a failed queue job
+- [`php artisan horizon:install`](https://artisan.page/10.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/10.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:listen`](https://artisan.page/10.x/horizonlisten.md) — Run Horizon and automatically restart workers on file changes
+- [`php artisan horizon:pause`](https://artisan.page/10.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:pause-supervisor`](https://artisan.page/10.x/horizonpause-supervisor.md) — Pause a supervisor
+- [`php artisan horizon:publish`](https://artisan.page/10.x/horizonpublish.md) — Publish all of the Horizon resources
+- [`php artisan horizon:purge`](https://artisan.page/10.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/10.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/10.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/10.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisor-status`](https://artisan.page/10.x/horizonsupervisor-status.md) — Show the status for a given supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/10.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/10.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/10.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/10.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:check-ssr`](https://artisan.page/10.x/inertiacheck-ssr.md) — Check the Inertia SSR server health status
+- [`php artisan inertia:middleware`](https://artisan.page/10.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inertia:start-ssr`](https://artisan.page/10.x/inertiastart-ssr.md) — Start the Inertia SSR server
+- [`php artisan inertia:stop-ssr`](https://artisan.page/10.x/inertiastop-ssr.md) — Stop the Inertia SSR server
+- [`php artisan inspire`](https://artisan.page/10.x/inspire.md) — Display an inspiring quote
+- [`php artisan jetstream:install`](https://artisan.page/10.x/jetstreaminstall.md) — Install the Jetstream components and resources
+- [`php artisan key:generate`](https://artisan.page/10.x/keygenerate.md) — Set the application key
+- [`php artisan lang:publish`](https://artisan.page/10.x/langpublish.md) — Publish all language files that are available for customization
+- [`php artisan list`](https://artisan.page/10.x/list.md) — List commands
+- [`php artisan livewire:attribute`](https://artisan.page/10.x/livewireattribute.md) — Create a new Livewire attribute class
+- [`php artisan livewire:config`](https://artisan.page/10.x/livewireconfig.md) — Publish Livewire config file
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/10.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+- [`php artisan livewire:convert`](https://artisan.page/10.x/livewireconvert.md) — Convert a Livewire component between single-file and multi-file formats
+- [`php artisan livewire:form`](https://artisan.page/10.x/livewireform.md) — Create a new Livewire form class
+- [`php artisan livewire:layout`](https://artisan.page/10.x/livewirelayout.md) — Create a new app layout file
+- [`php artisan livewire:make`](https://artisan.page/10.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:publish`](https://artisan.page/10.x/livewirepublish.md) — Publish Livewire configuration
+- [`php artisan livewire:stubs`](https://artisan.page/10.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan make:cast`](https://artisan.page/10.x/makecast.md) — Create a new custom Eloquent cast class
+- [`php artisan make:channel`](https://artisan.page/10.x/makechannel.md) — Create a new channel class
+- [`php artisan make:command`](https://artisan.page/10.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:component`](https://artisan.page/10.x/makecomponent.md) — Create a new view component class
+- [`php artisan make:controller`](https://artisan.page/10.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:event`](https://artisan.page/10.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/10.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/10.x/makefactory.md) — Create a new model factory
+- [`php artisan make:job`](https://artisan.page/10.x/makejob.md) — Create a new job class
+- [`php artisan make:listener`](https://artisan.page/10.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/10.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/10.x/makemail.md) — Create a new email class
+- [`php artisan make:middleware`](https://artisan.page/10.x/makemiddleware.md) — Create a new middleware class
+- [`php artisan make:migration`](https://artisan.page/10.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/10.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/10.x/makenotification.md) — Create a new notification class
+- [`php artisan make:observer`](https://artisan.page/10.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/10.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/10.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:request`](https://artisan.page/10.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/10.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/10.x/makerule.md) — Create a new validation rule
+- [`php artisan make:scope`](https://artisan.page/10.x/makescope.md) — Create a new scope class
+- [`php artisan make:seeder`](https://artisan.page/10.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:test`](https://artisan.page/10.x/maketest.md) — Create a new test class
+- [`php artisan make:view`](https://artisan.page/10.x/makeview.md) — Create a new view
+- [`php artisan make:volt`](https://artisan.page/10.x/makevolt.md) — Create a new Volt component
+- [`php artisan migrate`](https://artisan.page/10.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/10.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/10.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/10.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/10.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/10.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/10.x/migratestatus.md) — Show the status of each migration
+- [`php artisan model:prune`](https://artisan.page/10.x/modelprune.md) — Prune models that are no longer needed
+- [`php artisan model:show`](https://artisan.page/10.x/modelshow.md) — Show information about an Eloquent model
+- [`php artisan notifications:table`](https://artisan.page/10.x/notificationstable.md) — Create a migration for the notifications table
+- [`php artisan nova:action`](https://artisan.page/10.x/novaaction.md) — Create a new action class
+- [`php artisan nova:asset`](https://artisan.page/10.x/novaasset.md) — Create a new asset
+- [`php artisan nova:base-resource`](https://artisan.page/10.x/novabase-resource.md) — Create a new base resource class
+- [`php artisan nova:card`](https://artisan.page/10.x/novacard.md) — Create a new card
+- [`php artisan nova:check-license`](https://artisan.page/10.x/novacheck-license.md) — Verify your Nova license key
+- [`php artisan nova:custom-filter`](https://artisan.page/10.x/novacustom-filter.md) — Create a new custom filter
+- [`php artisan nova:dashboard`](https://artisan.page/10.x/novadashboard.md) — Create a new dashboard.
+- [`php artisan nova:field`](https://artisan.page/10.x/novafield.md) — Create a new field
+- [`php artisan nova:filter`](https://artisan.page/10.x/novafilter.md) — Create a new filter class
+- [`php artisan nova:install`](https://artisan.page/10.x/novainstall.md) — Install all of the Nova resources
+- [`php artisan nova:lens`](https://artisan.page/10.x/novalens.md) — Create a new lens class
+- [`php artisan nova:partition`](https://artisan.page/10.x/novapartition.md) — Create a new metric (partition) class
+- [`php artisan nova:policy`](https://artisan.page/10.x/novapolicy.md) — Create a new policy class
+- [`php artisan nova:progress`](https://artisan.page/10.x/novaprogress.md) — Create a new metric (progress) class
+- [`php artisan nova:publish`](https://artisan.page/10.x/novapublish.md) — Publish all of the Nova resources
+- [`php artisan nova:repeatable`](https://artisan.page/10.x/novarepeatable.md) — Create a new repeatable class
+- [`php artisan nova:resource`](https://artisan.page/10.x/novaresource.md) — Create a new resource class
+- [`php artisan nova:resource-tool`](https://artisan.page/10.x/novaresource-tool.md) — Create a new resource tool
+- [`php artisan nova:stubs`](https://artisan.page/10.x/novastubs.md) — Publish all stubs that are available for customization
+- [`php artisan nova:table`](https://artisan.page/10.x/novatable.md) — Create a new metric (table) class
+- [`php artisan nova:tool`](https://artisan.page/10.x/novatool.md) — Create a new tool
+- [`php artisan nova:translate`](https://artisan.page/10.x/novatranslate.md) — Create translation files for Nova
+- [`php artisan nova:trend`](https://artisan.page/10.x/novatrend.md) — Create a new metric (trend) class
+- [`php artisan nova:user`](https://artisan.page/10.x/novauser.md) — Create a new user
+- [`php artisan nova:value`](https://artisan.page/10.x/novavalue.md) — Create a new metric (single value) class
+- [`php artisan octane:frankenphp`](https://artisan.page/10.x/octanefrankenphp.md) — Start the Octane FrankenPHP server
+- [`php artisan octane:install`](https://artisan.page/10.x/octaneinstall.md) — Install the Octane components and resources
+- [`php artisan octane:reload`](https://artisan.page/10.x/octanereload.md) — Reload the Octane workers
+- [`php artisan octane:roadrunner`](https://artisan.page/10.x/octaneroadrunner.md) — Start the Octane RoadRunner server
+- [`php artisan octane:start`](https://artisan.page/10.x/octanestart.md) — Start the Octane server
+- [`php artisan octane:status`](https://artisan.page/10.x/octanestatus.md) — Get the current status of the Octane server
+- [`php artisan octane:stop`](https://artisan.page/10.x/octanestop.md) — Stop the Octane server
+- [`php artisan octane:swoole`](https://artisan.page/10.x/octaneswoole.md) — Start the Octane Swoole server
+- [`php artisan optimize`](https://artisan.page/10.x/optimize.md) — Cache the framework bootstrap files
+- [`php artisan optimize:clear`](https://artisan.page/10.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/10.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan passport:client`](https://artisan.page/10.x/passportclient.md) — Create a client for issuing access tokens
+- [`php artisan passport:hash`](https://artisan.page/10.x/passporthash.md) — Hash all of the existing secrets in the clients table
+- [`php artisan passport:install`](https://artisan.page/10.x/passportinstall.md) — Run the commands necessary to prepare Passport for use
+- [`php artisan passport:keys`](https://artisan.page/10.x/passportkeys.md) — Create the encryption keys for API authentication
+- [`php artisan passport:purge`](https://artisan.page/10.x/passportpurge.md) — Purge revoked and / or expired tokens and authentication codes
+- [`php artisan pennant:feature`](https://artisan.page/10.x/pennantfeature.md) — Create a new feature class
+- [`php artisan pennant:purge`](https://artisan.page/10.x/pennantpurge.md) — Delete Pennant features from storage
+- [`php artisan pulse:check`](https://artisan.page/10.x/pulsecheck.md) — Take a snapshot of the current server's pulse
+- [`php artisan pulse:clear`](https://artisan.page/10.x/pulseclear.md) — Delete all Pulse data from storage
+- [`php artisan pulse:restart`](https://artisan.page/10.x/pulserestart.md) — Restart any running "work" and "check" commands
+- [`php artisan pulse:work`](https://artisan.page/10.x/pulsework.md) — Process incoming Pulse data from the ingest stream
+- [`php artisan queue:batches-table`](https://artisan.page/10.x/queuebatches-table.md) — Create a migration for the batches database table
+- [`php artisan queue:clear`](https://artisan.page/10.x/queueclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan queue:failed`](https://artisan.page/10.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:failed-table`](https://artisan.page/10.x/queuefailed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan queue:flush`](https://artisan.page/10.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/10.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/10.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:monitor`](https://artisan.page/10.x/queuemonitor.md) — Monitor the size of the specified queues
+- [`php artisan queue:prune-batches`](https://artisan.page/10.x/queueprune-batches.md) — Prune stale entries from the batches database
+- [`php artisan queue:prune-failed`](https://artisan.page/10.x/queueprune-failed.md) — Prune stale entries from the failed jobs table
+- [`php artisan queue:restart`](https://artisan.page/10.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:retry`](https://artisan.page/10.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:retry-batch`](https://artisan.page/10.x/queueretry-batch.md) — Retry the failed jobs for a batch
+- [`php artisan queue:table`](https://artisan.page/10.x/queuetable.md) — Create a migration for the queue jobs database table
+- [`php artisan queue:work`](https://artisan.page/10.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan reverb:install`](https://artisan.page/10.x/reverbinstall.md) — Install the Reverb dependencies
+- [`php artisan reverb:restart`](https://artisan.page/10.x/reverbrestart.md) — Restart the Reverb server
+- [`php artisan reverb:start`](https://artisan.page/10.x/reverbstart.md) — Start the Reverb server
+- [`php artisan route:cache`](https://artisan.page/10.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/10.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/10.x/routelist.md) — List all registered routes
+- [`php artisan sail:add`](https://artisan.page/10.x/sailadd.md) — Add a service to an existing Sail installation
+- [`php artisan sail:install`](https://artisan.page/10.x/sailinstall.md) — Install Laravel Sail's default Docker Compose file
+- [`php artisan sail:publish`](https://artisan.page/10.x/sailpublish.md) — Publish the Laravel Sail Docker files
+- [`php artisan sanctum:prune-expired`](https://artisan.page/10.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours
+- [`php artisan schedule:clear-cache`](https://artisan.page/10.x/scheduleclear-cache.md) — Delete the cached mutex files created by scheduler
+- [`php artisan schedule:finish`](https://artisan.page/10.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:interrupt`](https://artisan.page/10.x/scheduleinterrupt.md) — Interrupt the current schedule run
+- [`php artisan schedule:list`](https://artisan.page/10.x/schedulelist.md) — List all scheduled tasks
+- [`php artisan schedule:run`](https://artisan.page/10.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan schedule:test`](https://artisan.page/10.x/scheduletest.md) — Run a scheduled command
+- [`php artisan schedule:work`](https://artisan.page/10.x/schedulework.md) — Start the schedule worker
+- [`php artisan schema:dump`](https://artisan.page/10.x/schemadump.md) — Dump the given database schema
+- [`php artisan scout:delete-all-indexes`](https://artisan.page/10.x/scoutdelete-all-indexes.md) — Delete all indexes
+- [`php artisan scout:delete-index`](https://artisan.page/10.x/scoutdelete-index.md) — Delete an index
+- [`php artisan scout:flush`](https://artisan.page/10.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/10.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan scout:index`](https://artisan.page/10.x/scoutindex.md) — Create an index
+- [`php artisan scout:queue-import`](https://artisan.page/10.x/scoutqueue-import.md) — Import the given model into the search index via chunked, queued jobs
+- [`php artisan scout:sync-index-settings`](https://artisan.page/10.x/scoutsync-index-settings.md) — Sync your configured index settings with your search engine (Meilisearch)
+- [`php artisan serve`](https://artisan.page/10.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan session:table`](https://artisan.page/10.x/sessiontable.md) — Create a migration for the session database table
+- [`php artisan spark:install`](https://artisan.page/10.x/sparkinstall.md) — Install all of the Spark resources
+- [`php artisan storage:link`](https://artisan.page/10.x/storagelink.md) — Create the symbolic links configured for the application
+- [`php artisan storage:unlink`](https://artisan.page/10.x/storageunlink.md) — Delete existing symbolic links configured for the application
+- [`php artisan stub:publish`](https://artisan.page/10.x/stubpublish.md) — Publish all stubs that are available for customization
+- [`php artisan telescope:clear`](https://artisan.page/10.x/telescopeclear.md) — Delete all Telescope data from storage
+- [`php artisan telescope:install`](https://artisan.page/10.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:pause`](https://artisan.page/10.x/telescopepause.md) — Pause all Telescope watchers
+- [`php artisan telescope:prune`](https://artisan.page/10.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/10.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan telescope:resume`](https://artisan.page/10.x/telescoperesume.md) — Unpause all Telescope watchers
+- [`php artisan test`](https://artisan.page/10.x/test.md) — Run the application tests
+- [`php artisan tinker`](https://artisan.page/10.x/tinker.md) — Interact with your application
+- [`php artisan up`](https://artisan.page/10.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vapor:handle`](https://artisan.page/10.x/vaporhandle.md)
+- [`php artisan vapor:health-check`](https://artisan.page/10.x/vaporhealth-check.md) — Check the health of the Vapor application
+- [`php artisan vapor:queue-failed`](https://artisan.page/10.x/vaporqueue-failed.md) — List all of the failed queue jobs
+- [`php artisan vapor:schedule`](https://artisan.page/10.x/vaporschedule.md) — Run the scheduled commands at the beginning of every minute
+- [`php artisan vapor:work`](https://artisan.page/10.x/vaporwork.md) — Process a Vapor job
+- [`php artisan vendor:publish`](https://artisan.page/10.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/10.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/10.x/viewclear.md) — Clear all compiled view files
+- [`php artisan volt:install`](https://artisan.page/10.x/voltinstall.md) — Install all of the Volt resources
 
-Full sitemap available at: https://artisan.page/sitemap.xml
+## Laravel 9.x
 
-## Source
+- [`php artisan _complete`](https://artisan.page/9.x/_complete.md) — Internal command to provide shell completion suggestions
+- [`php artisan about`](https://artisan.page/9.x/about.md) — Display basic information about your application
+- [`php artisan auth:clear-resets`](https://artisan.page/9.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan breeze:install`](https://artisan.page/9.x/breezeinstall.md) — Install the Breeze controllers and resources
+- [`php artisan cache:clear`](https://artisan.page/9.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/9.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:table`](https://artisan.page/9.x/cachetable.md) — Create a migration for the cache database table
+- [`php artisan cashier:webhook`](https://artisan.page/9.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier.
+- [`php artisan clear-compiled`](https://artisan.page/9.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan completion`](https://artisan.page/9.x/completion.md) — Dump the shell completion script
+- [`php artisan config:cache`](https://artisan.page/9.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/9.x/configclear.md) — Remove the configuration cache file
+- [`php artisan db`](https://artisan.page/9.x/db.md) — Start a new database CLI session
+- [`php artisan db:monitor`](https://artisan.page/9.x/dbmonitor.md) — Monitor the number of connections on the specified database
+- [`php artisan db:seed`](https://artisan.page/9.x/dbseed.md) — Seed the database with records
+- [`php artisan db:show`](https://artisan.page/9.x/dbshow.md) — Display information about the given database
+- [`php artisan db:table`](https://artisan.page/9.x/dbtable.md) — Display information about the given database table
+- [`php artisan db:wipe`](https://artisan.page/9.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan docs`](https://artisan.page/9.x/docs.md) — Access the Laravel documentation
+- [`php artisan down`](https://artisan.page/9.x/down.md) — Put the application into maintenance / demo mode
+- [`php artisan dusk`](https://artisan.page/9.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/9.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/9.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/9.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/9.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/9.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/9.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/9.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/9.x/env.md) — Display the current framework environment
+- [`php artisan env:decrypt`](https://artisan.page/9.x/envdecrypt.md) — Decrypt an environment file
+- [`php artisan env:encrypt`](https://artisan.page/9.x/envencrypt.md) — Encrypt an environment file
+- [`php artisan event:cache`](https://artisan.page/9.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/9.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/9.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/9.x/eventlist.md) — List the application's events and listeners
+- [`php artisan help`](https://artisan.page/9.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/9.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:clear`](https://artisan.page/9.x/horizonclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan horizon:clear-metrics`](https://artisan.page/9.x/horizonclear-metrics.md) — Delete metrics for all jobs and queues
+- [`php artisan horizon:continue`](https://artisan.page/9.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:continue-supervisor`](https://artisan.page/9.x/horizoncontinue-supervisor.md) — Instruct the supervisor to continue processing jobs
+- [`php artisan horizon:forget`](https://artisan.page/9.x/horizonforget.md) — Delete a failed queue job
+- [`php artisan horizon:install`](https://artisan.page/9.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/9.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:pause`](https://artisan.page/9.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:pause-supervisor`](https://artisan.page/9.x/horizonpause-supervisor.md) — Pause a supervisor
+- [`php artisan horizon:publish`](https://artisan.page/9.x/horizonpublish.md) — Publish all of the Horizon resources
+- [`php artisan horizon:purge`](https://artisan.page/9.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/9.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/9.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/9.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/9.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/9.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/9.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/9.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:middleware`](https://artisan.page/9.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inertia:start-ssr`](https://artisan.page/9.x/inertiastart-ssr.md) — Start the Inertia SSR server
+- [`php artisan inertia:stop-ssr`](https://artisan.page/9.x/inertiastop-ssr.md) — Stop the Inertia SSR server
+- [`php artisan inspire`](https://artisan.page/9.x/inspire.md) — Display an inspiring quote
+- [`php artisan jetstream:install`](https://artisan.page/9.x/jetstreaminstall.md) — Install the Jetstream components and resources
+- [`php artisan key:generate`](https://artisan.page/9.x/keygenerate.md) — Set the application key
+- [`php artisan list`](https://artisan.page/9.x/list.md) — List commands
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/9.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+- [`php artisan livewire:copy`](https://artisan.page/9.x/livewirecopy.md) — Copy a Livewire component
+- [`php artisan livewire:cp`](https://artisan.page/9.x/livewirecp.md) — Copy a Livewire component
+- [`php artisan livewire:delete`](https://artisan.page/9.x/livewiredelete.md) — Delete a Livewire component
+- [`php artisan livewire:discover`](https://artisan.page/9.x/livewirediscover.md) — Regenerate Livewire component auto-discovery manifest
+- [`php artisan livewire:make`](https://artisan.page/9.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:move`](https://artisan.page/9.x/livewiremove.md) — Move a Livewire component
+- [`php artisan livewire:mv`](https://artisan.page/9.x/livewiremv.md) — Move a Livewire component
+- [`php artisan livewire:publish`](https://artisan.page/9.x/livewirepublish.md) — Publish Livewire configuration
+- [`php artisan livewire:rm`](https://artisan.page/9.x/livewirerm.md) — Delete a Livewire component
+- [`php artisan livewire:stubs`](https://artisan.page/9.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan livewire:touch`](https://artisan.page/9.x/livewiretouch.md) — Create a new Livewire component
+- [`php artisan make:cast`](https://artisan.page/9.x/makecast.md) — Create a new custom Eloquent cast class
+- [`php artisan make:channel`](https://artisan.page/9.x/makechannel.md) — Create a new channel class
+- [`php artisan make:command`](https://artisan.page/9.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:component`](https://artisan.page/9.x/makecomponent.md) — Create a new view component class
+- [`php artisan make:controller`](https://artisan.page/9.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:event`](https://artisan.page/9.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/9.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/9.x/makefactory.md) — Create a new model factory
+- [`php artisan make:job`](https://artisan.page/9.x/makejob.md) — Create a new job class
+- [`php artisan make:listener`](https://artisan.page/9.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/9.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/9.x/makemail.md) — Create a new email class
+- [`php artisan make:middleware`](https://artisan.page/9.x/makemiddleware.md) — Create a new middleware class
+- [`php artisan make:migration`](https://artisan.page/9.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/9.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/9.x/makenotification.md) — Create a new notification class
+- [`php artisan make:observer`](https://artisan.page/9.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/9.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/9.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:request`](https://artisan.page/9.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/9.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/9.x/makerule.md) — Create a new validation rule
+- [`php artisan make:scope`](https://artisan.page/9.x/makescope.md) — Create a new scope class
+- [`php artisan make:seeder`](https://artisan.page/9.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:test`](https://artisan.page/9.x/maketest.md) — Create a new test class
+- [`php artisan migrate`](https://artisan.page/9.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/9.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/9.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/9.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/9.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/9.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/9.x/migratestatus.md) — Show the status of each migration
+- [`php artisan model:prune`](https://artisan.page/9.x/modelprune.md) — Prune models that are no longer needed
+- [`php artisan model:show`](https://artisan.page/9.x/modelshow.md) — Show information about an Eloquent model
+- [`php artisan notifications:table`](https://artisan.page/9.x/notificationstable.md) — Create a migration for the notifications table
+- [`php artisan optimize`](https://artisan.page/9.x/optimize.md) — Cache the framework bootstrap files
+- [`php artisan optimize:clear`](https://artisan.page/9.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/9.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan queue:batches-table`](https://artisan.page/9.x/queuebatches-table.md) — Create a migration for the batches database table
+- [`php artisan queue:clear`](https://artisan.page/9.x/queueclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan queue:failed`](https://artisan.page/9.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:failed-table`](https://artisan.page/9.x/queuefailed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan queue:flush`](https://artisan.page/9.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/9.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/9.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:monitor`](https://artisan.page/9.x/queuemonitor.md) — Monitor the size of the specified queues
+- [`php artisan queue:prune-batches`](https://artisan.page/9.x/queueprune-batches.md) — Prune stale entries from the batches database
+- [`php artisan queue:prune-failed`](https://artisan.page/9.x/queueprune-failed.md) — Prune stale entries from the failed jobs table
+- [`php artisan queue:restart`](https://artisan.page/9.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:retry`](https://artisan.page/9.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:retry-batch`](https://artisan.page/9.x/queueretry-batch.md) — Retry the failed jobs for a batch
+- [`php artisan queue:table`](https://artisan.page/9.x/queuetable.md) — Create a migration for the queue jobs database table
+- [`php artisan queue:work`](https://artisan.page/9.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan route:cache`](https://artisan.page/9.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/9.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/9.x/routelist.md) — List all registered routes
+- [`php artisan sail:add`](https://artisan.page/9.x/sailadd.md) — Add a service to an existing Sail installation
+- [`php artisan sail:install`](https://artisan.page/9.x/sailinstall.md) — Install Laravel Sail's default Docker Compose file
+- [`php artisan sail:publish`](https://artisan.page/9.x/sailpublish.md) — Publish the Laravel Sail Docker files
+- [`php artisan sanctum:prune-expired`](https://artisan.page/9.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours
+- [`php artisan schedule:clear-cache`](https://artisan.page/9.x/scheduleclear-cache.md) — Delete the cached mutex files created by scheduler
+- [`php artisan schedule:finish`](https://artisan.page/9.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:list`](https://artisan.page/9.x/schedulelist.md) — List all scheduled tasks
+- [`php artisan schedule:run`](https://artisan.page/9.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan schedule:test`](https://artisan.page/9.x/scheduletest.md) — Run a scheduled command
+- [`php artisan schedule:work`](https://artisan.page/9.x/schedulework.md) — Start the schedule worker
+- [`php artisan schema:dump`](https://artisan.page/9.x/schemadump.md) — Dump the given database schema
+- [`php artisan scout:delete-all-indexes`](https://artisan.page/9.x/scoutdelete-all-indexes.md) — Delete all indexes
+- [`php artisan scout:delete-index`](https://artisan.page/9.x/scoutdelete-index.md) — Delete an index
+- [`php artisan scout:flush`](https://artisan.page/9.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/9.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan scout:index`](https://artisan.page/9.x/scoutindex.md) — Create an index
+- [`php artisan scout:sync-index-settings`](https://artisan.page/9.x/scoutsync-index-settings.md) — Sync your configured index settings with your search engine (Meilisearch)
+- [`php artisan serve`](https://artisan.page/9.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan session:table`](https://artisan.page/9.x/sessiontable.md) — Create a migration for the session database table
+- [`php artisan storage:link`](https://artisan.page/9.x/storagelink.md) — Create the symbolic links configured for the application
+- [`php artisan stub:publish`](https://artisan.page/9.x/stubpublish.md) — Publish all stubs that are available for customization
+- [`php artisan telescope:clear`](https://artisan.page/9.x/telescopeclear.md) — Clear all entries from Telescope
+- [`php artisan telescope:install`](https://artisan.page/9.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:pause`](https://artisan.page/9.x/telescopepause.md) — Pause all Telescope watchers
+- [`php artisan telescope:prune`](https://artisan.page/9.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/9.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan telescope:resume`](https://artisan.page/9.x/telescoperesume.md) — Unpause all Telescope watchers
+- [`php artisan test`](https://artisan.page/9.x/test.md) — Run the application tests
+- [`php artisan tinker`](https://artisan.page/9.x/tinker.md) — Interact with your application
+- [`php artisan up`](https://artisan.page/9.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vendor:publish`](https://artisan.page/9.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/9.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/9.x/viewclear.md) — Clear all compiled view files
 
-Open source on GitHub: https://github.com/jbrooksuk/artisan.page
+## Laravel 8.x
+
+- [`php artisan _complete`](https://artisan.page/8.x/_complete.md) — Internal command to provide shell completion suggestions
+- [`php artisan auth:clear-resets`](https://artisan.page/8.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan breeze:install`](https://artisan.page/8.x/breezeinstall.md) — Install the Breeze controllers and resources
+- [`php artisan cache:clear`](https://artisan.page/8.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/8.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:table`](https://artisan.page/8.x/cachetable.md) — Create a migration for the cache database table
+- [`php artisan cashier:webhook`](https://artisan.page/8.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier.
+- [`php artisan clear-compiled`](https://artisan.page/8.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan completion`](https://artisan.page/8.x/completion.md) — Dump the shell completion script
+- [`php artisan config:cache`](https://artisan.page/8.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/8.x/configclear.md) — Remove the configuration cache file
+- [`php artisan db`](https://artisan.page/8.x/db.md) — Start a new database CLI session
+- [`php artisan db:seed`](https://artisan.page/8.x/dbseed.md) — Seed the database with records
+- [`php artisan db:wipe`](https://artisan.page/8.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan down`](https://artisan.page/8.x/down.md) — Put the application into maintenance / demo mode
+- [`php artisan dusk`](https://artisan.page/8.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/8.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/8.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/8.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/8.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/8.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/8.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/8.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/8.x/env.md) — Display the current framework environment
+- [`php artisan event:cache`](https://artisan.page/8.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/8.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/8.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/8.x/eventlist.md) — List the application's events and listeners
+- [`php artisan help`](https://artisan.page/8.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/8.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:clear`](https://artisan.page/8.x/horizonclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan horizon:clear-metrics`](https://artisan.page/8.x/horizonclear-metrics.md) — Delete metrics for all jobs and queues
+- [`php artisan horizon:continue`](https://artisan.page/8.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:continue-supervisor`](https://artisan.page/8.x/horizoncontinue-supervisor.md) — Instruct the supervisor to continue processing jobs
+- [`php artisan horizon:forget`](https://artisan.page/8.x/horizonforget.md) — Delete a failed queue job
+- [`php artisan horizon:install`](https://artisan.page/8.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/8.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:pause`](https://artisan.page/8.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:pause-supervisor`](https://artisan.page/8.x/horizonpause-supervisor.md) — Pause a supervisor
+- [`php artisan horizon:publish`](https://artisan.page/8.x/horizonpublish.md) — Publish all of the Horizon resources
+- [`php artisan horizon:purge`](https://artisan.page/8.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/8.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/8.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/8.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/8.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/8.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/8.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/8.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:middleware`](https://artisan.page/8.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inspire`](https://artisan.page/8.x/inspire.md) — Display an inspiring quote
+- [`php artisan jetstream:install`](https://artisan.page/8.x/jetstreaminstall.md) — Install the Jetstream components and resources
+- [`php artisan key:generate`](https://artisan.page/8.x/keygenerate.md) — Set the application key
+- [`php artisan list`](https://artisan.page/8.x/list.md) — List commands
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/8.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+- [`php artisan livewire:copy`](https://artisan.page/8.x/livewirecopy.md) — Copy a Livewire component
+- [`php artisan livewire:cp`](https://artisan.page/8.x/livewirecp.md) — Copy a Livewire component
+- [`php artisan livewire:delete`](https://artisan.page/8.x/livewiredelete.md) — Delete a Livewire component
+- [`php artisan livewire:discover`](https://artisan.page/8.x/livewirediscover.md) — Regenerate Livewire component auto-discovery manifest
+- [`php artisan livewire:make`](https://artisan.page/8.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:move`](https://artisan.page/8.x/livewiremove.md) — Move a Livewire component
+- [`php artisan livewire:mv`](https://artisan.page/8.x/livewiremv.md) — Move a Livewire component
+- [`php artisan livewire:publish`](https://artisan.page/8.x/livewirepublish.md) — Publish Livewire configuration
+- [`php artisan livewire:rm`](https://artisan.page/8.x/livewirerm.md) — Delete a Livewire component
+- [`php artisan livewire:stubs`](https://artisan.page/8.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan livewire:touch`](https://artisan.page/8.x/livewiretouch.md) — Create a new Livewire component
+- [`php artisan make:cast`](https://artisan.page/8.x/makecast.md) — Create a new custom Eloquent cast class
+- [`php artisan make:channel`](https://artisan.page/8.x/makechannel.md) — Create a new channel class
+- [`php artisan make:command`](https://artisan.page/8.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:component`](https://artisan.page/8.x/makecomponent.md) — Create a new view component class
+- [`php artisan make:controller`](https://artisan.page/8.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:event`](https://artisan.page/8.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/8.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/8.x/makefactory.md) — Create a new model factory
+- [`php artisan make:job`](https://artisan.page/8.x/makejob.md) — Create a new job class
+- [`php artisan make:listener`](https://artisan.page/8.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/8.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/8.x/makemail.md) — Create a new email class
+- [`php artisan make:middleware`](https://artisan.page/8.x/makemiddleware.md) — Create a new middleware class
+- [`php artisan make:migration`](https://artisan.page/8.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/8.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/8.x/makenotification.md) — Create a new notification class
+- [`php artisan make:observer`](https://artisan.page/8.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/8.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/8.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:request`](https://artisan.page/8.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/8.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/8.x/makerule.md) — Create a new validation rule
+- [`php artisan make:seeder`](https://artisan.page/8.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:test`](https://artisan.page/8.x/maketest.md) — Create a new test class
+- [`php artisan migrate`](https://artisan.page/8.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/8.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/8.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/8.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/8.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/8.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/8.x/migratestatus.md) — Show the status of each migration
+- [`php artisan model:prune`](https://artisan.page/8.x/modelprune.md) — Prune models that are no longer needed
+- [`php artisan notifications:table`](https://artisan.page/8.x/notificationstable.md) — Create a migration for the notifications table
+- [`php artisan nova:action`](https://artisan.page/8.x/novaaction.md) — Create a new action class
+- [`php artisan nova:asset`](https://artisan.page/8.x/novaasset.md) — Create a new asset
+- [`php artisan nova:base-resource`](https://artisan.page/8.x/novabase-resource.md) — Create a new base resource class
+- [`php artisan nova:card`](https://artisan.page/8.x/novacard.md) — Create a new card
+- [`php artisan nova:check-license`](https://artisan.page/8.x/novacheck-license.md) — Verify your Nova license key
+- [`php artisan nova:custom-filter`](https://artisan.page/8.x/novacustom-filter.md) — Create a new custom filter
+- [`php artisan nova:dashboard`](https://artisan.page/8.x/novadashboard.md) — Create a new dashboard.
+- [`php artisan nova:field`](https://artisan.page/8.x/novafield.md) — Create a new field
+- [`php artisan nova:filter`](https://artisan.page/8.x/novafilter.md) — Create a new filter class
+- [`php artisan nova:install`](https://artisan.page/8.x/novainstall.md) — Install all of the Nova resources
+- [`php artisan nova:lens`](https://artisan.page/8.x/novalens.md) — Create a new lens class
+- [`php artisan nova:partition`](https://artisan.page/8.x/novapartition.md) — Create a new metric (partition) class
+- [`php artisan nova:progress`](https://artisan.page/8.x/novaprogress.md) — Create a new metric (progress) class
+- [`php artisan nova:publish`](https://artisan.page/8.x/novapublish.md) — Publish all of the Nova resources
+- [`php artisan nova:repeatable`](https://artisan.page/8.x/novarepeatable.md) — Create a new repeatable class
+- [`php artisan nova:resource`](https://artisan.page/8.x/novaresource.md) — Create a new resource class
+- [`php artisan nova:resource-tool`](https://artisan.page/8.x/novaresource-tool.md) — Create a new resource tool
+- [`php artisan nova:stubs`](https://artisan.page/8.x/novastubs.md) — Publish all stubs that are available for customization
+- [`php artisan nova:table`](https://artisan.page/8.x/novatable.md) — Create a new metric (table) class
+- [`php artisan nova:tool`](https://artisan.page/8.x/novatool.md) — Create a new tool
+- [`php artisan nova:translate`](https://artisan.page/8.x/novatranslate.md) — Create translation files for Nova
+- [`php artisan nova:trend`](https://artisan.page/8.x/novatrend.md) — Create a new metric (trend) class
+- [`php artisan nova:upgrade`](https://artisan.page/8.x/novaupgrade.md) — Upgrade Laravel Nova 3 to 4
+- [`php artisan nova:user`](https://artisan.page/8.x/novauser.md) — Create a new user
+- [`php artisan nova:value`](https://artisan.page/8.x/novavalue.md) — Create a new metric (single value) class
+- [`php artisan octane:install`](https://artisan.page/8.x/octaneinstall.md) — Install the Octane components and resources
+- [`php artisan octane:reload`](https://artisan.page/8.x/octanereload.md) — Reload the Octane workers
+- [`php artisan octane:roadrunner`](https://artisan.page/8.x/octaneroadrunner.md) — Start the Octane RoadRunner server
+- [`php artisan octane:start`](https://artisan.page/8.x/octanestart.md) — Start the Octane server
+- [`php artisan octane:status`](https://artisan.page/8.x/octanestatus.md) — Get the current status of the Octane server
+- [`php artisan octane:stop`](https://artisan.page/8.x/octanestop.md) — Stop the Octane server
+- [`php artisan octane:swoole`](https://artisan.page/8.x/octaneswoole.md) — Start the Octane Swoole server
+- [`php artisan optimize`](https://artisan.page/8.x/optimize.md) — Cache the framework bootstrap files
+- [`php artisan optimize:clear`](https://artisan.page/8.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/8.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan passport:client`](https://artisan.page/8.x/passportclient.md) — Create a client for issuing access tokens
+- [`php artisan passport:hash`](https://artisan.page/8.x/passporthash.md) — Hash all of the existing secrets in the clients table
+- [`php artisan passport:install`](https://artisan.page/8.x/passportinstall.md) — Run the commands necessary to prepare Passport for use
+- [`php artisan passport:keys`](https://artisan.page/8.x/passportkeys.md) — Create the encryption keys for API authentication
+- [`php artisan passport:purge`](https://artisan.page/8.x/passportpurge.md) — Purge revoked and / or expired tokens and authentication codes
+- [`php artisan queue:batches-table`](https://artisan.page/8.x/queuebatches-table.md) — Create a migration for the batches database table
+- [`php artisan queue:clear`](https://artisan.page/8.x/queueclear.md) — Delete all of the jobs from the specified queue
+- [`php artisan queue:failed`](https://artisan.page/8.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:failed-table`](https://artisan.page/8.x/queuefailed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan queue:flush`](https://artisan.page/8.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/8.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/8.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:monitor`](https://artisan.page/8.x/queuemonitor.md) — Monitor the size of the specified queues
+- [`php artisan queue:prune-batches`](https://artisan.page/8.x/queueprune-batches.md) — Prune stale entries from the batches database
+- [`php artisan queue:prune-failed`](https://artisan.page/8.x/queueprune-failed.md) — Prune stale entries from the failed jobs table
+- [`php artisan queue:restart`](https://artisan.page/8.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:retry`](https://artisan.page/8.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:retry-batch`](https://artisan.page/8.x/queueretry-batch.md) — Retry the failed jobs for a batch
+- [`php artisan queue:table`](https://artisan.page/8.x/queuetable.md) — Create a migration for the queue jobs database table
+- [`php artisan queue:work`](https://artisan.page/8.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan route:cache`](https://artisan.page/8.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/8.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/8.x/routelist.md) — List all registered routes
+- [`php artisan sail:add`](https://artisan.page/8.x/sailadd.md) — Add a service to an existing Sail installation
+- [`php artisan sail:install`](https://artisan.page/8.x/sailinstall.md) — Install Laravel Sail's default Docker Compose file
+- [`php artisan sail:publish`](https://artisan.page/8.x/sailpublish.md) — Publish the Laravel Sail Docker files
+- [`php artisan sanctum:prune-expired`](https://artisan.page/8.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours.
+- [`php artisan schedule:clear-cache`](https://artisan.page/8.x/scheduleclear-cache.md) — Delete the cached mutex files created by scheduler
+- [`php artisan schedule:finish`](https://artisan.page/8.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:list`](https://artisan.page/8.x/schedulelist.md) — List the scheduled commands
+- [`php artisan schedule:run`](https://artisan.page/8.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan schedule:test`](https://artisan.page/8.x/scheduletest.md) — Run a scheduled command
+- [`php artisan schedule:work`](https://artisan.page/8.x/schedulework.md) — Start the schedule worker
+- [`php artisan schema:dump`](https://artisan.page/8.x/schemadump.md) — Dump the given database schema
+- [`php artisan scout:delete-all-indexes`](https://artisan.page/8.x/scoutdelete-all-indexes.md) — Delete all indexes
+- [`php artisan scout:delete-index`](https://artisan.page/8.x/scoutdelete-index.md) — Delete an index
+- [`php artisan scout:flush`](https://artisan.page/8.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/8.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan scout:index`](https://artisan.page/8.x/scoutindex.md) — Create an index
+- [`php artisan scout:sync-index-settings`](https://artisan.page/8.x/scoutsync-index-settings.md) — Sync your configured index settings with your search engine (MeiliSearch)
+- [`php artisan serve`](https://artisan.page/8.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan session:table`](https://artisan.page/8.x/sessiontable.md) — Create a migration for the session database table
+- [`php artisan spark:install`](https://artisan.page/8.x/sparkinstall.md) — Install all of the Spark resources
+- [`php artisan storage:link`](https://artisan.page/8.x/storagelink.md) — Create the symbolic links configured for the application
+- [`php artisan stub:publish`](https://artisan.page/8.x/stubpublish.md) — Publish all stubs that are available for customization
+- [`php artisan telescope:clear`](https://artisan.page/8.x/telescopeclear.md) — Delete all Telescope data from storage
+- [`php artisan telescope:install`](https://artisan.page/8.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:pause`](https://artisan.page/8.x/telescopepause.md) — Pause all Telescope watchers
+- [`php artisan telescope:prune`](https://artisan.page/8.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/8.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan telescope:resume`](https://artisan.page/8.x/telescoperesume.md) — Unpause all Telescope watchers
+- [`php artisan test`](https://artisan.page/8.x/test.md) — Run the application tests
+- [`php artisan tinker`](https://artisan.page/8.x/tinker.md) — Interact with your application
+- [`php artisan ui`](https://artisan.page/8.x/ui.md) — Swap the front-end scaffolding for the application
+- [`php artisan ui:auth`](https://artisan.page/8.x/uiauth.md) — Scaffold basic login and registration views and routes
+- [`php artisan ui:controllers`](https://artisan.page/8.x/uicontrollers.md) — Scaffold the authentication controllers
+- [`php artisan up`](https://artisan.page/8.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vapor:handle`](https://artisan.page/8.x/vaporhandle.md)
+- [`php artisan vapor:health-check`](https://artisan.page/8.x/vaporhealth-check.md) — Check the health of the Vapor application
+- [`php artisan vapor:queue-failed`](https://artisan.page/8.x/vaporqueue-failed.md) — List all of the failed queue jobs
+- [`php artisan vapor:schedule`](https://artisan.page/8.x/vaporschedule.md) — Run the scheduled commands at the beginning of every minute
+- [`php artisan vapor:work`](https://artisan.page/8.x/vaporwork.md) — Process a Vapor job
+- [`php artisan vendor:publish`](https://artisan.page/8.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/8.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/8.x/viewclear.md) — Clear all compiled view files
+
+## Laravel 7.x
+
+- [`php artisan _complete`](https://artisan.page/7.x/_complete.md) — Internal command to provide shell completion suggestions
+- [`php artisan auth:clear-resets`](https://artisan.page/7.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan cache:clear`](https://artisan.page/7.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/7.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:table`](https://artisan.page/7.x/cachetable.md) — Create a migration for the cache database table
+- [`php artisan cashier:webhook`](https://artisan.page/7.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier.
+- [`php artisan clear-compiled`](https://artisan.page/7.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan completion`](https://artisan.page/7.x/completion.md) — Dump the shell completion script
+- [`php artisan config:cache`](https://artisan.page/7.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/7.x/configclear.md) — Remove the configuration cache file
+- [`php artisan db:seed`](https://artisan.page/7.x/dbseed.md) — Seed the database with records
+- [`php artisan db:wipe`](https://artisan.page/7.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan down`](https://artisan.page/7.x/down.md) — Put the application into maintenance mode
+- [`php artisan dusk`](https://artisan.page/7.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/7.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/7.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/7.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/7.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/7.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/7.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/7.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/7.x/env.md) — Display the current framework environment
+- [`php artisan event:cache`](https://artisan.page/7.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/7.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/7.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/7.x/eventlist.md) — List the application's events and listeners
+- [`php artisan help`](https://artisan.page/7.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/7.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:continue`](https://artisan.page/7.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:install`](https://artisan.page/7.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/7.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:pause`](https://artisan.page/7.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:publish`](https://artisan.page/7.x/horizonpublish.md) — Publish all of the Horizon resources
+- [`php artisan horizon:purge`](https://artisan.page/7.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/7.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/7.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/7.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/7.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/7.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/7.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/7.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:middleware`](https://artisan.page/7.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inertia:start-ssr`](https://artisan.page/7.x/inertiastart-ssr.md) — Start the Inertia SSR server
+- [`php artisan inertia:stop-ssr`](https://artisan.page/7.x/inertiastop-ssr.md) — Stop the Inertia SSR server
+- [`php artisan inspire`](https://artisan.page/7.x/inspire.md) — Display an inspiring quote
+- [`php artisan key:generate`](https://artisan.page/7.x/keygenerate.md) — Set the application key
+- [`php artisan list`](https://artisan.page/7.x/list.md) — List commands
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/7.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs
+- [`php artisan livewire:copy`](https://artisan.page/7.x/livewirecopy.md) — Copy a Livewire component
+- [`php artisan livewire:cp`](https://artisan.page/7.x/livewirecp.md) — Copy a Livewire component
+- [`php artisan livewire:delete`](https://artisan.page/7.x/livewiredelete.md) — Delete a Livewire component
+- [`php artisan livewire:discover`](https://artisan.page/7.x/livewirediscover.md) — Regenerate Livewire component auto-discovery manifest
+- [`php artisan livewire:make`](https://artisan.page/7.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:move`](https://artisan.page/7.x/livewiremove.md) — Move a Livewire component
+- [`php artisan livewire:mv`](https://artisan.page/7.x/livewiremv.md) — Move a Livewire component
+- [`php artisan livewire:publish`](https://artisan.page/7.x/livewirepublish.md) — Publish Livewire configuration
+- [`php artisan livewire:rm`](https://artisan.page/7.x/livewirerm.md) — Delete a Livewire component
+- [`php artisan livewire:stubs`](https://artisan.page/7.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan livewire:touch`](https://artisan.page/7.x/livewiretouch.md) — Create a new Livewire component
+- [`php artisan make:cast`](https://artisan.page/7.x/makecast.md) — Create a new custom Eloquent cast class
+- [`php artisan make:channel`](https://artisan.page/7.x/makechannel.md) — Create a new channel class
+- [`php artisan make:command`](https://artisan.page/7.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:component`](https://artisan.page/7.x/makecomponent.md) — Create a new view component class
+- [`php artisan make:controller`](https://artisan.page/7.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:event`](https://artisan.page/7.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/7.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/7.x/makefactory.md) — Create a new model factory
+- [`php artisan make:job`](https://artisan.page/7.x/makejob.md) — Create a new job class
+- [`php artisan make:listener`](https://artisan.page/7.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/7.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/7.x/makemail.md) — Create a new email class
+- [`php artisan make:middleware`](https://artisan.page/7.x/makemiddleware.md) — Create a new middleware class
+- [`php artisan make:migration`](https://artisan.page/7.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/7.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/7.x/makenotification.md) — Create a new notification class
+- [`php artisan make:observer`](https://artisan.page/7.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/7.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/7.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:request`](https://artisan.page/7.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/7.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/7.x/makerule.md) — Create a new validation rule
+- [`php artisan make:seeder`](https://artisan.page/7.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:test`](https://artisan.page/7.x/maketest.md) — Create a new test class
+- [`php artisan migrate`](https://artisan.page/7.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/7.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/7.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/7.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/7.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/7.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/7.x/migratestatus.md) — Show the status of each migration
+- [`php artisan notifications:table`](https://artisan.page/7.x/notificationstable.md) — Create a migration for the notifications table
+- [`php artisan nova:action`](https://artisan.page/7.x/novaaction.md) — Create a new action class
+- [`php artisan nova:asset`](https://artisan.page/7.x/novaasset.md) — Create a new asset
+- [`php artisan nova:base-resource`](https://artisan.page/7.x/novabase-resource.md) — Create a new base resource class
+- [`php artisan nova:card`](https://artisan.page/7.x/novacard.md) — Create a new card
+- [`php artisan nova:custom-filter`](https://artisan.page/7.x/novacustom-filter.md) — Create a new custom filter
+- [`php artisan nova:dashboard`](https://artisan.page/7.x/novadashboard.md) — Create a new dashboard.
+- [`php artisan nova:field`](https://artisan.page/7.x/novafield.md) — Create a new field
+- [`php artisan nova:filter`](https://artisan.page/7.x/novafilter.md) — Create a new filter class
+- [`php artisan nova:install`](https://artisan.page/7.x/novainstall.md) — Install all of the Nova resources
+- [`php artisan nova:lens`](https://artisan.page/7.x/novalens.md) — Create a new lens class
+- [`php artisan nova:partition`](https://artisan.page/7.x/novapartition.md) — Create a new metric (partition) class
+- [`php artisan nova:publish`](https://artisan.page/7.x/novapublish.md) — Publish all of the Nova resources
+- [`php artisan nova:resource`](https://artisan.page/7.x/novaresource.md) — Create a new resource class
+- [`php artisan nova:resource-tool`](https://artisan.page/7.x/novaresource-tool.md) — Create a new resource tool
+- [`php artisan nova:stubs`](https://artisan.page/7.x/novastubs.md) — Publish all stubs that are available for customization
+- [`php artisan nova:theme`](https://artisan.page/7.x/novatheme.md) — Create a new theme
+- [`php artisan nova:tool`](https://artisan.page/7.x/novatool.md) — Create a new tool
+- [`php artisan nova:translate`](https://artisan.page/7.x/novatranslate.md) — Create translation files for Nova
+- [`php artisan nova:trend`](https://artisan.page/7.x/novatrend.md) — Create a new metric (trend) class
+- [`php artisan nova:user`](https://artisan.page/7.x/novauser.md) — Create a new user
+- [`php artisan nova:value`](https://artisan.page/7.x/novavalue.md) — Create a new metric (single value) class
+- [`php artisan optimize`](https://artisan.page/7.x/optimize.md) — Cache the framework bootstrap files
+- [`php artisan optimize:clear`](https://artisan.page/7.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/7.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan passport:client`](https://artisan.page/7.x/passportclient.md) — Create a client for issuing access tokens
+- [`php artisan passport:hash`](https://artisan.page/7.x/passporthash.md) — Hash all of the existing secrets in the clients table
+- [`php artisan passport:install`](https://artisan.page/7.x/passportinstall.md) — Run the commands necessary to prepare Passport for use
+- [`php artisan passport:keys`](https://artisan.page/7.x/passportkeys.md) — Create the encryption keys for API authentication
+- [`php artisan passport:purge`](https://artisan.page/7.x/passportpurge.md) — Purge revoked and / or expired tokens and authentication codes
+- [`php artisan queue:failed`](https://artisan.page/7.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:failed-table`](https://artisan.page/7.x/queuefailed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan queue:flush`](https://artisan.page/7.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/7.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/7.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:restart`](https://artisan.page/7.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:retry`](https://artisan.page/7.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:table`](https://artisan.page/7.x/queuetable.md) — Create a migration for the queue jobs database table
+- [`php artisan queue:work`](https://artisan.page/7.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan route:cache`](https://artisan.page/7.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/7.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/7.x/routelist.md) — List all registered routes
+- [`php artisan sanctum:prune-expired`](https://artisan.page/7.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours.
+- [`php artisan schedule:finish`](https://artisan.page/7.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:run`](https://artisan.page/7.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan scout:flush`](https://artisan.page/7.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/7.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan serve`](https://artisan.page/7.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan session:table`](https://artisan.page/7.x/sessiontable.md) — Create a migration for the session database table
+- [`php artisan storage:link`](https://artisan.page/7.x/storagelink.md) — Create the symbolic links configured for the application
+- [`php artisan stub:publish`](https://artisan.page/7.x/stubpublish.md) — Publish all stubs that are available for customization
+- [`php artisan telescope:clear`](https://artisan.page/7.x/telescopeclear.md) — Clear all entries from Telescope
+- [`php artisan telescope:install`](https://artisan.page/7.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:prune`](https://artisan.page/7.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/7.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan test`](https://artisan.page/7.x/test.md) — Run the application tests
+- [`php artisan tinker`](https://artisan.page/7.x/tinker.md) — Interact with your application
+- [`php artisan ui`](https://artisan.page/7.x/ui.md) — Swap the front-end scaffolding for the application
+- [`php artisan ui:auth`](https://artisan.page/7.x/uiauth.md) — Scaffold basic login and registration views and routes
+- [`php artisan ui:controllers`](https://artisan.page/7.x/uicontrollers.md) — Scaffold the authentication controllers
+- [`php artisan up`](https://artisan.page/7.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vapor:handle`](https://artisan.page/7.x/vaporhandle.md)
+- [`php artisan vapor:health-check`](https://artisan.page/7.x/vaporhealth-check.md) — Check the health of the Vapor application
+- [`php artisan vapor:queue-failed`](https://artisan.page/7.x/vaporqueue-failed.md) — List all of the failed queue jobs
+- [`php artisan vapor:schedule`](https://artisan.page/7.x/vaporschedule.md) — Run the scheduled commands at the beginning of every minute
+- [`php artisan vapor:work`](https://artisan.page/7.x/vaporwork.md) — Process a Vapor job
+- [`php artisan vendor:publish`](https://artisan.page/7.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/7.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/7.x/viewclear.md) — Clear all compiled view files
+
+## Laravel 6.x
+
+- [`php artisan auth:clear-resets`](https://artisan.page/6.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan cache:clear`](https://artisan.page/6.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/6.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:table`](https://artisan.page/6.x/cachetable.md) — Create a migration for the cache database table
+- [`php artisan cashier:webhook`](https://artisan.page/6.x/cashierwebhook.md) — Create the Stripe webhook to interact with Cashier.
+- [`php artisan clear-compiled`](https://artisan.page/6.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan config:cache`](https://artisan.page/6.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/6.x/configclear.md) — Remove the configuration cache file
+- [`php artisan db:seed`](https://artisan.page/6.x/dbseed.md) — Seed the database with records
+- [`php artisan db:wipe`](https://artisan.page/6.x/dbwipe.md) — Drop all tables, views, and types
+- [`php artisan down`](https://artisan.page/6.x/down.md) — Put the application into maintenance mode
+- [`php artisan dusk`](https://artisan.page/6.x/dusk.md) — Run the Dusk tests for the application
+- [`php artisan dusk:chrome-driver`](https://artisan.page/6.x/duskchrome-driver.md) — Install the ChromeDriver binary
+- [`php artisan dusk:component`](https://artisan.page/6.x/duskcomponent.md) — Create a new Dusk component class
+- [`php artisan dusk:fails`](https://artisan.page/6.x/duskfails.md) — Run the failing Dusk tests from the last run and stop on failure
+- [`php artisan dusk:install`](https://artisan.page/6.x/duskinstall.md) — Install Dusk into the application
+- [`php artisan dusk:make`](https://artisan.page/6.x/duskmake.md) — Create a new Dusk test class
+- [`php artisan dusk:page`](https://artisan.page/6.x/duskpage.md) — Create a new Dusk page class
+- [`php artisan dusk:purge`](https://artisan.page/6.x/duskpurge.md) — Purge dusk test debugging files
+- [`php artisan env`](https://artisan.page/6.x/env.md) — Display the current framework environment
+- [`php artisan event:cache`](https://artisan.page/6.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/6.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/6.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/6.x/eventlist.md) — List the application's events and listeners
+- [`php artisan help`](https://artisan.page/6.x/help.md) — Display help for a command
+- [`php artisan horizon`](https://artisan.page/6.x/horizon.md) — Start a master supervisor in the foreground
+- [`php artisan horizon:assets`](https://artisan.page/6.x/horizonassets.md) — Re-publish the Horizon assets
+- [`php artisan horizon:continue`](https://artisan.page/6.x/horizoncontinue.md) — Instruct the master supervisor to continue processing jobs
+- [`php artisan horizon:install`](https://artisan.page/6.x/horizoninstall.md) — Install all of the Horizon resources
+- [`php artisan horizon:list`](https://artisan.page/6.x/horizonlist.md) — List all of the deployed machines
+- [`php artisan horizon:pause`](https://artisan.page/6.x/horizonpause.md) — Pause the master supervisor
+- [`php artisan horizon:purge`](https://artisan.page/6.x/horizonpurge.md) — Terminate any rogue Horizon processes
+- [`php artisan horizon:snapshot`](https://artisan.page/6.x/horizonsnapshot.md) — Store a snapshot of the queue metrics
+- [`php artisan horizon:status`](https://artisan.page/6.x/horizonstatus.md) — Get the current status of Horizon
+- [`php artisan horizon:supervisor`](https://artisan.page/6.x/horizonsupervisor.md) — Start a new supervisor
+- [`php artisan horizon:supervisors`](https://artisan.page/6.x/horizonsupervisors.md) — List all of the supervisors
+- [`php artisan horizon:terminate`](https://artisan.page/6.x/horizonterminate.md) — Terminate the master supervisor so it can be restarted
+- [`php artisan horizon:timeout`](https://artisan.page/6.x/horizontimeout.md) — Get the maximum timeout for the given environment
+- [`php artisan horizon:work`](https://artisan.page/6.x/horizonwork.md) — Start processing jobs on the queue as a daemon
+- [`php artisan inertia:middleware`](https://artisan.page/6.x/inertiamiddleware.md) — Create a new Inertia middleware
+- [`php artisan inertia:start-ssr`](https://artisan.page/6.x/inertiastart-ssr.md) — Start the Inertia SSR server
+- [`php artisan inertia:stop-ssr`](https://artisan.page/6.x/inertiastop-ssr.md) — Stop the Inertia SSR server
+- [`php artisan inspire`](https://artisan.page/6.x/inspire.md) — Display an inspiring quote
+- [`php artisan key:generate`](https://artisan.page/6.x/keygenerate.md) — Set the application key
+- [`php artisan list`](https://artisan.page/6.x/list.md) — List commands
+- [`php artisan livewire:configure-s3-upload-cleanup`](https://artisan.page/6.x/livewireconfigure-s3-upload-cleanup.md) — Configure temporary file upload s3 directory to automatically cleanup files older than 24hrs.
+- [`php artisan livewire:copy`](https://artisan.page/6.x/livewirecopy.md) — Copy a Livewire component
+- [`php artisan livewire:cp`](https://artisan.page/6.x/livewirecp.md) — Copy a Livewire component
+- [`php artisan livewire:delete`](https://artisan.page/6.x/livewiredelete.md) — Delete a Livewire component
+- [`php artisan livewire:discover`](https://artisan.page/6.x/livewirediscover.md) — Regenerate Livewire component auto-discovery manifest
+- [`php artisan livewire:make`](https://artisan.page/6.x/livewiremake.md) — Create a new Livewire component
+- [`php artisan livewire:move`](https://artisan.page/6.x/livewiremove.md) — Move a Livewire component
+- [`php artisan livewire:mv`](https://artisan.page/6.x/livewiremv.md) — Move a Livewire component
+- [`php artisan livewire:rm`](https://artisan.page/6.x/livewirerm.md) — Delete a Livewire component
+- [`php artisan livewire:stubs`](https://artisan.page/6.x/livewirestubs.md) — Publish Livewire stubs
+- [`php artisan livewire:touch`](https://artisan.page/6.x/livewiretouch.md) — Create a new Livewire component
+- [`php artisan make:channel`](https://artisan.page/6.x/makechannel.md) — Create a new channel class
+- [`php artisan make:command`](https://artisan.page/6.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:controller`](https://artisan.page/6.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:event`](https://artisan.page/6.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/6.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/6.x/makefactory.md) — Create a new model factory
+- [`php artisan make:job`](https://artisan.page/6.x/makejob.md) — Create a new job class
+- [`php artisan make:listener`](https://artisan.page/6.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:livewire`](https://artisan.page/6.x/makelivewire.md) — Create a new Livewire component
+- [`php artisan make:mail`](https://artisan.page/6.x/makemail.md) — Create a new email class
+- [`php artisan make:middleware`](https://artisan.page/6.x/makemiddleware.md) — Create a new middleware class
+- [`php artisan make:migration`](https://artisan.page/6.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/6.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/6.x/makenotification.md) — Create a new notification class
+- [`php artisan make:observer`](https://artisan.page/6.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/6.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/6.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:request`](https://artisan.page/6.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/6.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/6.x/makerule.md) — Create a new validation rule
+- [`php artisan make:seeder`](https://artisan.page/6.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:test`](https://artisan.page/6.x/maketest.md) — Create a new test class
+- [`php artisan migrate`](https://artisan.page/6.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/6.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/6.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/6.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/6.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/6.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/6.x/migratestatus.md) — Show the status of each migration
+- [`php artisan notifications:table`](https://artisan.page/6.x/notificationstable.md) — Create a migration for the notifications table
+- [`php artisan nova:action`](https://artisan.page/6.x/novaaction.md) — Create a new action class
+- [`php artisan nova:asset`](https://artisan.page/6.x/novaasset.md) — Create a new asset
+- [`php artisan nova:base-resource`](https://artisan.page/6.x/novabase-resource.md) — Create a new base resource class
+- [`php artisan nova:card`](https://artisan.page/6.x/novacard.md) — Create a new card
+- [`php artisan nova:custom-filter`](https://artisan.page/6.x/novacustom-filter.md) — Create a new custom filter
+- [`php artisan nova:dashboard`](https://artisan.page/6.x/novadashboard.md) — Create a new dashboard.
+- [`php artisan nova:field`](https://artisan.page/6.x/novafield.md) — Create a new field
+- [`php artisan nova:filter`](https://artisan.page/6.x/novafilter.md) — Create a new filter class
+- [`php artisan nova:install`](https://artisan.page/6.x/novainstall.md) — Install all of the Nova resources
+- [`php artisan nova:lens`](https://artisan.page/6.x/novalens.md) — Create a new lens class
+- [`php artisan nova:partition`](https://artisan.page/6.x/novapartition.md) — Create a new metric (partition) class
+- [`php artisan nova:publish`](https://artisan.page/6.x/novapublish.md) — Publish all of the Nova resources
+- [`php artisan nova:resource`](https://artisan.page/6.x/novaresource.md) — Create a new resource class
+- [`php artisan nova:resource-tool`](https://artisan.page/6.x/novaresource-tool.md) — Create a new resource tool
+- [`php artisan nova:theme`](https://artisan.page/6.x/novatheme.md) — Create a new theme
+- [`php artisan nova:tool`](https://artisan.page/6.x/novatool.md) — Create a new tool
+- [`php artisan nova:trend`](https://artisan.page/6.x/novatrend.md) — Create a new metric (trend) class
+- [`php artisan nova:user`](https://artisan.page/6.x/novauser.md) — Create a new user
+- [`php artisan nova:value`](https://artisan.page/6.x/novavalue.md) — Create a new metric (single value) class
+- [`php artisan optimize`](https://artisan.page/6.x/optimize.md) — Cache the framework bootstrap files
+- [`php artisan optimize:clear`](https://artisan.page/6.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/6.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan passport:client`](https://artisan.page/6.x/passportclient.md) — Create a client for issuing access tokens
+- [`php artisan passport:hash`](https://artisan.page/6.x/passporthash.md) — Hash all of the existing secrets in the clients table
+- [`php artisan passport:install`](https://artisan.page/6.x/passportinstall.md) — Run the commands necessary to prepare Passport for use
+- [`php artisan passport:keys`](https://artisan.page/6.x/passportkeys.md) — Create the encryption keys for API authentication
+- [`php artisan passport:purge`](https://artisan.page/6.x/passportpurge.md) — Purge revoked and / or expired tokens and authentication codes
+- [`php artisan preset`](https://artisan.page/6.x/preset.md) — Swap the front-end scaffolding for the application
+- [`php artisan queue:failed`](https://artisan.page/6.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:failed-table`](https://artisan.page/6.x/queuefailed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan queue:flush`](https://artisan.page/6.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/6.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/6.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:restart`](https://artisan.page/6.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:retry`](https://artisan.page/6.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:table`](https://artisan.page/6.x/queuetable.md) — Create a migration for the queue jobs database table
+- [`php artisan queue:work`](https://artisan.page/6.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan route:cache`](https://artisan.page/6.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/6.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/6.x/routelist.md) — List all registered routes
+- [`php artisan sanctum:prune-expired`](https://artisan.page/6.x/sanctumprune-expired.md) — Prune tokens expired for more than specified number of hours.
+- [`php artisan schedule:finish`](https://artisan.page/6.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:run`](https://artisan.page/6.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan scout:flush`](https://artisan.page/6.x/scoutflush.md) — Flush all of the model's records from the index
+- [`php artisan scout:import`](https://artisan.page/6.x/scoutimport.md) — Import the given model into the search index
+- [`php artisan serve`](https://artisan.page/6.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan session:table`](https://artisan.page/6.x/sessiontable.md) — Create a migration for the session database table
+- [`php artisan storage:link`](https://artisan.page/6.x/storagelink.md) — Create a symbolic link from "public/storage" to "storage/app/public"
+- [`php artisan telescope:clear`](https://artisan.page/6.x/telescopeclear.md) — Clear all entries from Telescope
+- [`php artisan telescope:install`](https://artisan.page/6.x/telescopeinstall.md) — Install all of the Telescope resources
+- [`php artisan telescope:prune`](https://artisan.page/6.x/telescopeprune.md) — Prune stale entries from the Telescope database
+- [`php artisan telescope:publish`](https://artisan.page/6.x/telescopepublish.md) — Publish all of the Telescope resources
+- [`php artisan tinker`](https://artisan.page/6.x/tinker.md) — Interact with your application
+- [`php artisan up`](https://artisan.page/6.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vapor:handle`](https://artisan.page/6.x/vaporhandle.md)
+- [`php artisan vapor:health-check`](https://artisan.page/6.x/vaporhealth-check.md) — Check the health of the Vapor application
+- [`php artisan vapor:queue-failed`](https://artisan.page/6.x/vaporqueue-failed.md) — List all of the failed queue jobs
+- [`php artisan vapor:schedule`](https://artisan.page/6.x/vaporschedule.md) — Run the scheduled commands at the beginning of every minute
+- [`php artisan vapor:work`](https://artisan.page/6.x/vaporwork.md) — Process a Vapor job
+- [`php artisan vendor:publish`](https://artisan.page/6.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/6.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/6.x/viewclear.md) — Clear all compiled view files
+
+## Laravel 5.x
+
+- [`php artisan app:name`](https://artisan.page/5.x/appname.md) — Set the application namespace
+- [`php artisan auth:clear-resets`](https://artisan.page/5.x/authclear-resets.md) — Flush expired password reset tokens
+- [`php artisan cache:clear`](https://artisan.page/5.x/cacheclear.md) — Flush the application cache
+- [`php artisan cache:forget`](https://artisan.page/5.x/cacheforget.md) — Remove an item from the cache
+- [`php artisan cache:table`](https://artisan.page/5.x/cachetable.md) — Create a migration for the cache database table
+- [`php artisan clear-compiled`](https://artisan.page/5.x/clear-compiled.md) — Remove the compiled class file
+- [`php artisan config:cache`](https://artisan.page/5.x/configcache.md) — Create a cache file for faster configuration loading
+- [`php artisan config:clear`](https://artisan.page/5.x/configclear.md) — Remove the configuration cache file
+- [`php artisan db:seed`](https://artisan.page/5.x/dbseed.md) — Seed the database with records
+- [`php artisan down`](https://artisan.page/5.x/down.md) — Put the application into maintenance mode
+- [`php artisan dump-server`](https://artisan.page/5.x/dump-server.md) — Start the dump server to collect dump information.
+- [`php artisan env`](https://artisan.page/5.x/env.md) — Display the current framework environment
+- [`php artisan event:cache`](https://artisan.page/5.x/eventcache.md) — Discover and cache the application's events and listeners
+- [`php artisan event:clear`](https://artisan.page/5.x/eventclear.md) — Clear all cached events and listeners
+- [`php artisan event:generate`](https://artisan.page/5.x/eventgenerate.md) — Generate the missing events and listeners based on registration
+- [`php artisan event:list`](https://artisan.page/5.x/eventlist.md) — List the application's events and listeners
+- [`php artisan help`](https://artisan.page/5.x/help.md) — Display help for a command
+- [`php artisan inspire`](https://artisan.page/5.x/inspire.md) — Display an inspiring quote
+- [`php artisan key:generate`](https://artisan.page/5.x/keygenerate.md) — Set the application key
+- [`php artisan list`](https://artisan.page/5.x/list.md) — List commands
+- [`php artisan make:auth`](https://artisan.page/5.x/makeauth.md) — Scaffold basic login and registration views and routes
+- [`php artisan make:channel`](https://artisan.page/5.x/makechannel.md) — Create a new channel class
+- [`php artisan make:command`](https://artisan.page/5.x/makecommand.md) — Create a new Artisan command
+- [`php artisan make:controller`](https://artisan.page/5.x/makecontroller.md) — Create a new controller class
+- [`php artisan make:event`](https://artisan.page/5.x/makeevent.md) — Create a new event class
+- [`php artisan make:exception`](https://artisan.page/5.x/makeexception.md) — Create a new custom exception class
+- [`php artisan make:factory`](https://artisan.page/5.x/makefactory.md) — Create a new model factory
+- [`php artisan make:job`](https://artisan.page/5.x/makejob.md) — Create a new job class
+- [`php artisan make:listener`](https://artisan.page/5.x/makelistener.md) — Create a new event listener class
+- [`php artisan make:mail`](https://artisan.page/5.x/makemail.md) — Create a new email class
+- [`php artisan make:middleware`](https://artisan.page/5.x/makemiddleware.md) — Create a new middleware class
+- [`php artisan make:migration`](https://artisan.page/5.x/makemigration.md) — Create a new migration file
+- [`php artisan make:model`](https://artisan.page/5.x/makemodel.md) — Create a new Eloquent model class
+- [`php artisan make:notification`](https://artisan.page/5.x/makenotification.md) — Create a new notification class
+- [`php artisan make:observer`](https://artisan.page/5.x/makeobserver.md) — Create a new observer class
+- [`php artisan make:policy`](https://artisan.page/5.x/makepolicy.md) — Create a new policy class
+- [`php artisan make:provider`](https://artisan.page/5.x/makeprovider.md) — Create a new service provider class
+- [`php artisan make:request`](https://artisan.page/5.x/makerequest.md) — Create a new form request class
+- [`php artisan make:resource`](https://artisan.page/5.x/makeresource.md) — Create a new resource
+- [`php artisan make:rule`](https://artisan.page/5.x/makerule.md) — Create a new validation rule
+- [`php artisan make:seeder`](https://artisan.page/5.x/makeseeder.md) — Create a new seeder class
+- [`php artisan make:test`](https://artisan.page/5.x/maketest.md) — Create a new test class
+- [`php artisan migrate`](https://artisan.page/5.x/migrate.md) — Run the database migrations
+- [`php artisan migrate:fresh`](https://artisan.page/5.x/migratefresh.md) — Drop all tables and re-run all migrations
+- [`php artisan migrate:install`](https://artisan.page/5.x/migrateinstall.md) — Create the migration repository
+- [`php artisan migrate:refresh`](https://artisan.page/5.x/migraterefresh.md) — Reset and re-run all migrations
+- [`php artisan migrate:reset`](https://artisan.page/5.x/migratereset.md) — Rollback all database migrations
+- [`php artisan migrate:rollback`](https://artisan.page/5.x/migraterollback.md) — Rollback the last database migration
+- [`php artisan migrate:status`](https://artisan.page/5.x/migratestatus.md) — Show the status of each migration
+- [`php artisan notifications:table`](https://artisan.page/5.x/notificationstable.md) — Create a migration for the notifications table
+- [`php artisan optimize`](https://artisan.page/5.x/optimize.md) — Cache the framework bootstrap files
+- [`php artisan optimize:clear`](https://artisan.page/5.x/optimizeclear.md) — Remove the cached bootstrap files
+- [`php artisan package:discover`](https://artisan.page/5.x/packagediscover.md) — Rebuild the cached package manifest
+- [`php artisan preset`](https://artisan.page/5.x/preset.md) — Swap the front-end scaffolding for the application
+- [`php artisan queue:failed`](https://artisan.page/5.x/queuefailed.md) — List all of the failed queue jobs
+- [`php artisan queue:failed-table`](https://artisan.page/5.x/queuefailed-table.md) — Create a migration for the failed queue jobs database table
+- [`php artisan queue:flush`](https://artisan.page/5.x/queueflush.md) — Flush all of the failed queue jobs
+- [`php artisan queue:forget`](https://artisan.page/5.x/queueforget.md) — Delete a failed queue job
+- [`php artisan queue:listen`](https://artisan.page/5.x/queuelisten.md) — Listen to a given queue
+- [`php artisan queue:restart`](https://artisan.page/5.x/queuerestart.md) — Restart queue worker daemons after their current job
+- [`php artisan queue:retry`](https://artisan.page/5.x/queueretry.md) — Retry a failed queue job
+- [`php artisan queue:table`](https://artisan.page/5.x/queuetable.md) — Create a migration for the queue jobs database table
+- [`php artisan queue:work`](https://artisan.page/5.x/queuework.md) — Start processing jobs on the queue as a daemon
+- [`php artisan route:cache`](https://artisan.page/5.x/routecache.md) — Create a route cache file for faster route registration
+- [`php artisan route:clear`](https://artisan.page/5.x/routeclear.md) — Remove the route cache file
+- [`php artisan route:list`](https://artisan.page/5.x/routelist.md) — List all registered routes
+- [`php artisan schedule:finish`](https://artisan.page/5.x/schedulefinish.md) — Handle the completion of a scheduled command
+- [`php artisan schedule:run`](https://artisan.page/5.x/schedulerun.md) — Run the scheduled commands
+- [`php artisan serve`](https://artisan.page/5.x/serve.md) — Serve the application on the PHP development server
+- [`php artisan session:table`](https://artisan.page/5.x/sessiontable.md) — Create a migration for the session database table
+- [`php artisan storage:link`](https://artisan.page/5.x/storagelink.md) — Create a symbolic link from "public/storage" to "storage/app/public"
+- [`php artisan tinker`](https://artisan.page/5.x/tinker.md) — Interact with your application
+- [`php artisan up`](https://artisan.page/5.x/up.md) — Bring the application out of maintenance mode
+- [`php artisan vendor:publish`](https://artisan.page/5.x/vendorpublish.md) — Publish any publishable assets from vendor packages
+- [`php artisan view:cache`](https://artisan.page/5.x/viewcache.md) — Compile all of the application's Blade templates
+- [`php artisan view:clear`](https://artisan.page/5.x/viewclear.md) — Clear all compiled view files

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -1,0 +1,113 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const siteUrl = 'https://artisan.page'
+
+const manifest = JSON.parse(await readFile(resolve(root, 'manifest.json'), 'utf8'))
+
+function commandUrl(version, command) {
+  return `${siteUrl}/${version}/${command.name.replaceAll(':', '')}.md`
+}
+
+function text(value) {
+  return value == null ? '' : String(value).replace(/\s+/g, ' ').trim()
+}
+
+function hasDefault(value) {
+  return value !== null && value !== undefined && value !== false && value !== ''
+    && !(Array.isArray(value) && value.length === 0)
+}
+
+function formatDefault(value) {
+  return typeof value === 'string' ? `\`${value}\`` : `\`${JSON.stringify(value)}\``
+}
+
+function renderCommand(command, version) {
+  const lines = [`### \`php artisan ${command.name}\``, '']
+  const description = text(command.description)
+
+  if (description) {
+    lines.push(description, '')
+  }
+
+  const synopsis = text(command.synopsis) || command.name
+  lines.push('```bash', `php artisan ${synopsis}`, '```')
+
+  const arguments_ = Array.isArray(command.arguments) ? command.arguments : []
+  if (arguments_.length) {
+    lines.push('', 'Arguments:')
+    for (const argument of arguments_) {
+      const required = argument.required ? ' (required)' : ''
+      const defaultValue = hasDefault(argument.default) ? `; default: ${formatDefault(argument.default)}` : ''
+      const argumentDescription = text(argument.description)
+      lines.push(`- \`${argument.name}\`${required}${argumentDescription ? ` — ${argumentDescription}` : ''}${defaultValue}`)
+    }
+  }
+
+  const options = Array.isArray(command.options) ? [...command.options] : []
+  if (options.length) {
+    lines.push('', 'Options:')
+    for (const option of options.sort((a, b) => a.name.localeCompare(b.name))) {
+      const value = option.value_required ? ' (value required)' : option.value_optional ? ' (value optional)' : ''
+      const defaultValue = hasDefault(option.default) ? `; default: ${formatDefault(option.default)}` : ''
+      const optionDescription = text(option.description)
+      lines.push(`- \`--${option.name}\`${value}${optionDescription ? ` — ${optionDescription}` : ''}${defaultValue}`)
+    }
+  }
+
+  const aliases = Array.isArray(command.aliases) ? command.aliases : []
+  if (aliases.length) {
+    lines.push('', `Aliases: ${aliases.map((alias) => `\`${alias}\``).join(', ')}`)
+  }
+
+  lines.push('', `Source: ${commandUrl(version, command)}`)
+  return lines.join('\n')
+}
+
+const commandSets = await Promise.all(manifest.laravel.map(async (version) => {
+  const path = resolve(root, 'assets', `${version}.json`)
+  const commands = JSON.parse(await readFile(path, 'utf8'))
+
+  if (!Array.isArray(commands)) {
+    throw new TypeError(`${path} must contain an array of commands`)
+  }
+
+  return [version, [...commands].sort((a, b) => a.name.localeCompare(b.name))]
+}))
+
+const index = [
+  '# Artisan.page',
+  '',
+  "> A complete, versioned reference for Laravel's `php artisan` commands.",
+  '',
+  `The latest supported release is Laravel ${manifest.laravel[0]}. Use the version-specific command links below, or read the [complete reference](${siteUrl}/llms-full.txt) for command synopses, arguments, options, defaults, and aliases.`,
+]
+
+const full = [
+  '# Artisan.page: Complete Artisan Command Reference',
+  '',
+  "> Every documented Laravel `php artisan` command, organised by framework version.",
+  '',
+  `For a compact index with links to each command page, see [llms.txt](${siteUrl}/llms.txt).`,
+]
+
+for (const [version, commands] of commandSets) {
+  index.push('', `## Laravel ${version}${version === manifest.laravel[0] ? ' (latest)' : ''}`, '')
+  for (const command of commands) {
+    const description = text(command.description)
+    index.push(`- [\`php artisan ${command.name}\`](${commandUrl(version, command)})${description ? ` — ${description}` : ''}`)
+  }
+
+  full.push('', `## Laravel ${version}`, '', `${commands.length} documented commands.`)
+  for (const command of commands) {
+    full.push('', renderCommand(command, version))
+  }
+}
+
+await mkdir(resolve(root, 'public'), { recursive: true })
+await Promise.all([
+  writeFile(resolve(root, 'public/llms.txt'), `${index.join('\n')}\n`),
+  writeFile(resolve(root, 'public/llms-full.txt'), `${full.join('\n')}\n`),
+])

--- a/server/middleware/markdown.js
+++ b/server/middleware/markdown.js
@@ -71,7 +71,7 @@ function renderHome() {
   lines.push('## Versions')
   lines.push('')
   for (const v of laravel) {
-    lines.push(`- [Laravel ${v}](https://artisan.page/${v}.md)`)
+    lines.push(`- [Laravel ${v}](https://artisan.page/${v})`)
   }
   lines.push('')
   lines.push('## Resources')
@@ -82,7 +82,7 @@ function renderHome() {
   return lines.join('\n')
 }
 
-function renderVersionIndex(version, commands) {
+function renderVersionIndex(version, commands, isMarkdownPath) {
   const lines = []
   lines.push(`# Laravel ${version} Artisan commands`)
   lines.push('')
@@ -95,14 +95,15 @@ function renderVersionIndex(version, commands) {
   for (const cmd of commands) {
     const slug = cmd.name.replace(':', '')
     const desc = cmd.description ? ` — ${cmd.description}` : ''
-    lines.push(`- [\`php artisan ${cmd.name}\`](https://artisan.page/${version}/${slug}.md)${desc}`)
+    const markdownExtension = isMarkdownPath ? '.md' : ''
+    lines.push(`- [\`php artisan ${cmd.name}\`](https://artisan.page/${version}/${slug}${markdownExtension})${desc}`)
   }
   lines.push('')
-  lines.push(`Source: https://artisan.page/${version}.md`)
+  lines.push(`Source: https://artisan.page/${version}${isMarkdownPath ? '.md' : ''}`)
   return lines.join('\n')
 }
 
-function renderCommand(command, version) {
+function renderCommand(command, version, isMarkdownPath) {
   const lines = []
   lines.push(`# \`php artisan ${command.name}\``)
   lines.push('')
@@ -154,7 +155,7 @@ function renderCommand(command, version) {
 
   const slug = command.name.replace(':', '')
   lines.push('')
-  lines.push(`Source: https://artisan.page/${version}/${slug}.md`)
+  lines.push(`Source: https://artisan.page/${version}/${slug}${isMarkdownPath ? '.md' : ''}`)
   return lines.join('\n')
 }
 
@@ -166,9 +167,10 @@ export default defineEventHandler(async (event) => {
   const parsed = parsePath(url.pathname)
   if (!parsed) return
 
+  if (!parsed.isMarkdownPath) setHeader(event, 'Vary', 'Accept')
+
   const accept = getHeader(event, 'accept')
   if (!parsed.isMarkdownPath && !prefersMarkdown(accept)) return
-  if (!parsed.isMarkdownPath) setHeader(event, 'Vary', 'Accept')
 
   let body
   if (parsed.route === 'index') {
@@ -176,13 +178,13 @@ export default defineEventHandler(async (event) => {
   } else if (parsed.route === 'version') {
     if (!laravel.includes(parsed.version)) return
     const commands = (await versionMap[parsed.version]()).default
-    body = renderVersionIndex(parsed.version, commands)
+    body = renderVersionIndex(parsed.version, commands, parsed.isMarkdownPath)
   } else if (parsed.route === 'command') {
     if (!laravel.includes(parsed.version)) return
     const commands = (await versionMap[parsed.version]()).default
     const match = commands.find((c) => c.name.replace(':', '') === parsed.command)
     if (!match) return
-    body = renderCommand(match, parsed.version)
+    body = renderCommand(match, parsed.version, parsed.isMarkdownPath)
   }
 
   if (!body) return

--- a/server/middleware/markdown.js
+++ b/server/middleware/markdown.js
@@ -34,16 +34,28 @@ function prefersMarkdown(accept) {
   return mdQ >= htmlQ
 }
 
+function hasDefault(value) {
+  return value !== null && value !== undefined && value !== false && value !== ''
+    && !(Array.isArray(value) && value.length === 0)
+}
+
+function formatDefault(value) {
+  return `; default: \`${typeof value === 'string' ? value : JSON.stringify(value)}\``
+}
+
 function parsePath(pathname) {
   const clean = pathname.replace(/\/+$/, '') || '/'
   if (clean === '/') return { route: 'index' }
 
-  const parts = clean.split('/').filter(Boolean)
+  const isMarkdownPath = clean.endsWith('.md')
+  const routePath = isMarkdownPath ? clean.slice(0, -3) : clean
+
+  const parts = routePath.split('/').filter(Boolean)
   if (parts.length === 1 && /^\d+\.x$/.test(parts[0])) {
-    return { route: 'version', version: parts[0] }
+    return { route: 'version', version: parts[0], isMarkdownPath }
   }
   if (parts.length === 2 && /^\d+\.x$/.test(parts[0]) && /^[\w-]+$/.test(parts[1])) {
-    return { route: 'command', version: parts[0], command: parts[1] }
+    return { route: 'command', version: parts[0], command: parts[1], isMarkdownPath }
   }
   return null
 }
@@ -59,7 +71,7 @@ function renderHome() {
   lines.push('## Versions')
   lines.push('')
   for (const v of laravel) {
-    lines.push(`- [Laravel ${v}](https://artisan.page/${v})`)
+    lines.push(`- [Laravel ${v}](https://artisan.page/${v}.md)`)
   }
   lines.push('')
   lines.push('## Resources')
@@ -83,10 +95,10 @@ function renderVersionIndex(version, commands) {
   for (const cmd of commands) {
     const slug = cmd.name.replace(':', '')
     const desc = cmd.description ? ` — ${cmd.description}` : ''
-    lines.push(`- [\`php artisan ${cmd.name}\`](https://artisan.page/${version}/${slug})${desc}`)
+    lines.push(`- [\`php artisan ${cmd.name}\`](https://artisan.page/${version}/${slug}.md)${desc}`)
   }
   lines.push('')
-  lines.push(`Source: https://artisan.page/${version}`)
+  lines.push(`Source: https://artisan.page/${version}.md`)
   return lines.join('\n')
 }
 
@@ -112,8 +124,9 @@ function renderCommand(command, version) {
     lines.push('')
     for (const arg of command.arguments) {
       const required = arg.required ? ' *(required)*' : ''
+      const defaultValue = hasDefault(arg.default) ? formatDefault(arg.default) : ''
       const description = arg.description ? ` — ${arg.description}` : ''
-      lines.push(`- \`${arg.name}\`${required}${description}`)
+      lines.push(`- \`${arg.name}\`${required}${description}${defaultValue}`)
     }
   }
 
@@ -123,9 +136,10 @@ function renderCommand(command, version) {
     lines.push('')
     const sorted = [...command.options].sort((a, b) => a.name.localeCompare(b.name))
     for (const opt of sorted) {
-      const required = opt.value_required ? ' *(value required)*' : ''
+      const value = opt.value_required ? ' *(value required)*' : opt.value_optional ? ' *(value optional)*' : ''
+      const defaultValue = hasDefault(opt.default) ? formatDefault(opt.default) : ''
       const description = opt.description ? ` — ${opt.description}` : ''
-      lines.push(`- \`--${opt.name}\`${required}${description}`)
+      lines.push(`- \`--${opt.name}\`${value}${description}${defaultValue}`)
     }
   }
 
@@ -140,7 +154,7 @@ function renderCommand(command, version) {
 
   const slug = command.name.replace(':', '')
   lines.push('')
-  lines.push(`Source: https://artisan.page/${version}/${slug}`)
+  lines.push(`Source: https://artisan.page/${version}/${slug}.md`)
   return lines.join('\n')
 }
 
@@ -152,10 +166,9 @@ export default defineEventHandler(async (event) => {
   const parsed = parsePath(url.pathname)
   if (!parsed) return
 
-  setHeader(event, 'Vary', 'Accept')
-
   const accept = getHeader(event, 'accept')
-  if (!prefersMarkdown(accept)) return
+  if (!parsed.isMarkdownPath && !prefersMarkdown(accept)) return
+  if (!parsed.isMarkdownPath) setHeader(event, 'Vary', 'Accept')
 
   let body
   if (parsed.route === 'index') {


### PR DESCRIPTION
## Summary

- generate compact `llms.txt` and comprehensive `llms-full.txt` references from the command data
- serve direct Markdown endpoints for version and command pages via `.md` paths
- pre-render Markdown routes and document their use for agents

## Verification

- `npm run generate:llms`
- `npm run build`