### PR TITLE
Add agent discovery Link headers

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -25,7 +25,17 @@ export default defineNuxtConfig({
   ssr: true,
 
   routeRules: {
-    '/': { prerender: true },
+    '/': {
+      prerender: true,
+      headers: {
+        Link: '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </llms.txt>; rel="service-doc"; type="text/plain"',
+      },
+    },
+    '/.well-known/api-catalog': {
+      headers: {
+        'Content-Type': 'application/linkset+json',
+      },
+    },
     '/**': { prerender: true },
     '/api/**': { prerender: false },
   },


### PR DESCRIPTION
## Summary

- advertise the API catalog and agent documentation from the homepage using RFC 8288 Link relations
- configure the API catalog response as application/linkset+json
- define the headers in Nuxt route rules so they work on Laravel Cloud

## Verification

- npm test (118 tests passed)
- npm run build
- verified the production homepage Link header and API catalog Content-Type with local HEAD requests