### PR TITLE
Persist sidebar searches in the query string

### DIFF
--- a/components/ArtisanBrowser.vue
+++ b/components/ArtisanBrowser.vue
@@ -192,11 +192,8 @@ export default {
   },
   created() {
     this.currentVersion = this.version || laravel[0]
+    this.filter = this.queryFilter(this.$route.query.q)
     this.loadData(this.currentVersion)
-  },
-  mounted() {
-    const { query } = this.$route
-    this.filter = query.search || ''
   },
   beforeUnmount() {
     if (this._observer) {
@@ -204,6 +201,13 @@ export default {
     }
   },
   watch: {
+    '$route.query.q'(value) {
+      const filter = this.queryFilter(value)
+
+      if (filter !== this.filter) {
+        this.filter = filter
+      }
+    },
     commandData() {
       window.location.hash &&
         this.$nextTick(() => {
@@ -263,7 +267,29 @@ export default {
       this.$refs.mainContent?.scroll({ top: 0, behavior: 'smooth' })
     },
     filterResults(value) {
-      this.filter = value.trim()
+      const filter = value.trim()
+      this.filter = filter
+
+      if (this.queryFilter(this.$route.query.q) === filter) {
+        return
+      }
+
+      const query = { ...this.$route.query }
+
+      if (filter) {
+        query.q = filter
+      } else {
+        delete query.q
+      }
+
+      this.$router.replace({ query, hash: this.$route.hash })
+    },
+    queryFilter(value) {
+      if (Array.isArray(value)) {
+        return value[0] || ''
+      }
+
+      return value || ''
     },
     setupScrollObserver() {
       if (this._observer) {

--- a/tests/component/artisan-browser.test.js
+++ b/tests/component/artisan-browser.test.js
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { shallowMount } from '@vue/test-utils'
+import { nextTick, reactive } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ArtisanBrowser from '~/components/ArtisanBrowser.vue'
+
+class IntersectionObserver {
+  observe() {}
+  disconnect() {}
+}
+
+const mountBrowser = (query = {}, hash = '') => {
+  const route = reactive({ query, hash })
+  const router = {
+    replace: vi.fn(({ query: nextQuery }) => {
+      route.query = nextQuery
+      return Promise.resolve()
+    }),
+  }
+
+  const wrapper = shallowMount(ArtisanBrowser, {
+    props: { version: '12.x' },
+    global: {
+      mocks: {
+        $route: route,
+        $router: router,
+      },
+    },
+  })
+
+  return { route, router, wrapper }
+}
+
+describe('ArtisanBrowser search query', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', IntersectionObserver)
+  })
+
+  it('restores the search from q when the page loads', () => {
+    const { wrapper } = mountBrowser({ q: 'migrate' })
+
+    expect(wrapper.vm.filter).toBe('migrate')
+  })
+
+  it('updates q while preserving other query parameters', () => {
+    const { router, wrapper } = mountBrowser({ ref: 'docs' }, '#cache-clear')
+
+    wrapper.vm.filterResults(' cache ')
+
+    expect(router.replace).toHaveBeenCalledWith({
+      query: { ref: 'docs', q: 'cache' },
+      hash: '#cache-clear',
+    })
+  })
+
+  it('removes q when the search is cleared', () => {
+    const { router, wrapper } = mountBrowser({ q: 'cache', ref: 'docs' })
+
+    wrapper.vm.filterResults('')
+
+    expect(router.replace).toHaveBeenCalledWith({
+      query: { ref: 'docs' },
+      hash: '',
+    })
+  })
+
+  it('tracks q changes from browser navigation', async () => {
+    const { route, wrapper } = mountBrowser({ q: 'cache' })
+
+    route.query.q = 'route'
+    await nextTick()
+
+    expect(wrapper.vm.filter).toBe('route')
+  })
+})


### PR DESCRIPTION
## Summary

- sync sidebar search state with the `q` query parameter
- restore searches on reload and browser navigation
- preserve unrelated query parameters and URL hashes
- remove `q` when the search is cleared

## Tests

- `npm test` (122 tests)
- `npm run build`